### PR TITLE
Initial pass at a vulkan abstraction.

### DIFF
--- a/xrtl/base/macros.h
+++ b/xrtl/base/macros.h
@@ -150,40 +150,40 @@ inline Dest bit_cast(const Source& source) {
 //  XRTL_BITMASK(MyBitmask);
 //  MyBitmask value = ~(MyBitmask::kFoo | MyBitmask::kBar);
 #define XRTL_BITMASK(enum_class)                                       \
-  enum_class operator|(enum_class lhs, enum_class rhs) {               \
+  inline enum_class operator|(enum_class lhs, enum_class rhs) {        \
     typedef typename std::underlying_type<enum_class>::type enum_type; \
     return static_cast<enum_class>(static_cast<enum_type>(lhs) |       \
                                    static_cast<enum_type>(rhs));       \
   }                                                                    \
-  enum_class& operator|=(enum_class& lhs, enum_class rhs) {            \
+  inline enum_class& operator|=(enum_class& lhs, enum_class rhs) {     \
     typedef typename std::underlying_type<enum_class>::type enum_type; \
     lhs = static_cast<enum_class>(static_cast<enum_type>(lhs) |        \
                                   static_cast<enum_type>(rhs));        \
     return lhs;                                                        \
   }                                                                    \
-  enum_class operator&(enum_class lhs, enum_class rhs) {               \
+  inline enum_class operator&(enum_class lhs, enum_class rhs) {        \
     typedef typename std::underlying_type<enum_class>::type enum_type; \
     return static_cast<enum_class>(static_cast<enum_type>(lhs) &       \
                                    static_cast<enum_type>(rhs));       \
   }                                                                    \
-  enum_class& operator&=(enum_class& lhs, enum_class rhs) {            \
+  inline enum_class& operator&=(enum_class& lhs, enum_class rhs) {     \
     typedef typename std::underlying_type<enum_class>::type enum_type; \
     lhs = static_cast<enum_class>(static_cast<enum_type>(lhs) &        \
                                   static_cast<enum_type>(rhs));        \
     return lhs;                                                        \
   }                                                                    \
-  enum_class operator^(enum_class lhs, enum_class rhs) {               \
+  inline enum_class operator^(enum_class lhs, enum_class rhs) {        \
     typedef typename std::underlying_type<enum_class>::type enum_type; \
     return static_cast<enum_class>(static_cast<enum_type>(lhs) ^       \
                                    static_cast<enum_type>(rhs));       \
   }                                                                    \
-  enum_class& operator^=(enum_class& lhs, enum_class rhs) {            \
+  inline enum_class& operator^=(enum_class& lhs, enum_class rhs) {     \
     typedef typename std::underlying_type<enum_class>::type enum_type; \
     lhs = static_cast<enum_class>(static_cast<enum_type>(lhs) ^        \
                                   static_cast<enum_type>(rhs));        \
     return lhs;                                                        \
   }                                                                    \
-  enum_class operator~(enum_class lhs) {                               \
+  inline enum_class operator~(enum_class lhs) {                        \
     typedef typename std::underlying_type<enum_class>::type enum_type; \
     return static_cast<enum_class>(~static_cast<enum_type>(lhs));      \
   }

--- a/xrtl/gfx/BUILD
+++ b/xrtl/gfx/BUILD
@@ -6,6 +6,14 @@ package(default_visibility = ["//xrtl:internal"])
 licenses(["notice"])  # Apache 2.0
 
 cc_library(
+    name = "buffer",
+    hdrs = ["buffer.h"],
+    deps = [
+        ":resource",
+    ],
+)
+
+cc_library(
     name = "color",
     srcs = ["color.cc"],
     hdrs = ["color.h"],
@@ -26,6 +34,183 @@ cc_test(
 )
 
 cc_library(
+    name = "command_buffer",
+    hdrs = ["command_buffer.h"],
+    deps = [
+        ":command_encoder",
+        ":framebuffer",
+        ":render_pass",
+        "//xrtl/base:logging",
+        "//xrtl/base:macros",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "command_encoder",
+    hdrs = ["command_encoder.h"],
+    deps = [
+        ":buffer",
+        ":command_fence",
+        ":image",
+        ":pipeline",
+        ":pipeline_layout",
+        ":resource_set",
+        ":sampler",
+        "//xrtl/base:array_view",
+        "//xrtl/base:logging",
+        "//xrtl/base:macros",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "command_fence",
+    hdrs = ["command_fence.h"],
+    deps = [
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "context",
+    hdrs = ["context.h"],
+    deps = [
+        ":command_buffer",
+        ":command_fence",
+        ":device",
+        ":framebuffer",
+        ":image_view",
+        ":memory_pool",
+        ":pipeline",
+        ":pipeline_layout",
+        ":pixel_format",
+        ":queue_fence",
+        ":render_pass",
+        ":resource_set",
+        ":sampler",
+        ":shader_module",
+        ":swap_chain",
+        "//xrtl/base:array_view",
+        "//xrtl/base:ref_ptr",
+        "//xrtl/base/threading:event",
+        "//xrtl/ui:control",
+    ],
+)
+
+cc_library(
+    name = "context_factory",
+    srcs = ["context_factory.cc"],
+    hdrs = ["context_factory.h"],
+    deps = [
+        ":context_factory_hdrs",
+        "//xrtl/base:flags",
+        "//xrtl/base:logging",
+    ] + select({
+        "//xrtl/tools/target_platform:android": [],
+        "//xrtl/tools/target_platform:emscripten": [],
+        "//xrtl/tools/target_platform:ios": [],
+        "//xrtl/tools/target_platform:linux": [],
+        "//xrtl/tools/target_platform:macos": [],
+        "//xrtl/tools/target_platform:windows": [],
+    }),
+)
+
+cc_library(
+    name = "context_factory_hdrs",
+    hdrs = ["context_factory.h"],
+    deps = [
+        ":context",
+        ":device",
+        "//xrtl/base:array_view",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_test(
+    name = "context_factory_test",
+    srcs = ["context_factory_test.cc"],
+    deps = [
+        ":context_factory",
+        "//xrtl/testing:gtest_main",
+    ],
+    size = "small",
+)
+
+cc_library(
+    name = "device",
+    hdrs = ["device.h"],
+    deps = [
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "framebuffer",
+    hdrs = ["framebuffer.h"],
+    deps = [
+        ":image_view",
+        ":render_pass",
+        "//xrtl/base:array_view",
+        "//xrtl/base:geometry",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "image",
+    hdrs = ["image.h"],
+    deps = [
+        ":render_state",
+        ":resource",
+        "//xrtl/base:geometry",
+    ],
+)
+
+cc_library(
+    name = "image_view",
+    hdrs = ["image_view.h"],
+    deps = [
+        ":pixel_format",
+        ":image",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "memory_pool",
+    hdrs = ["memory_pool.h"],
+    deps = [
+        ":buffer",
+        ":image",
+        ":resource",
+        "//xrtl/base:macros",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "pipeline",
+    hdrs = ["pipeline.h"],
+    deps = [
+        ":pipeline_layout",
+        ":shader_module",
+        ":render_state",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "pipeline_layout",
+    hdrs = ["pipeline_layout.h"],
+    deps = [
+        ":render_pass",
+        "//xrtl/base:array_view",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
     name = "pixel_format",
     srcs = ["pixel_format.cc"],
     hdrs = ["pixel_format.h"],
@@ -43,4 +228,85 @@ cc_test(
         "//xrtl/testing:gtest_main",
     ],
     size = "small",
+)
+
+cc_library(
+    name = "queue_fence",
+    hdrs = ["queue_fence.h"],
+    deps = [
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "render_pass",
+    hdrs = ["render_pass.h"],
+    deps = [
+        ":image",
+        ":pixel_format",
+        ":render_state",
+        "//xrtl/base:array_view",
+        "//xrtl/base:macros",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "render_state",
+    hdrs = ["render_state.h"],
+    deps = [
+        ":pixel_format",
+        "//xrtl/base:fixed_vector",
+    ],
+)
+
+cc_library(
+    name = "resource",
+    hdrs = ["resource.h"],
+    deps = [
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "resource_set",
+    hdrs = ["resource_set.h"],
+    deps = [
+        ":buffer",
+        ":image",
+        ":image_view",
+        ":pipeline_layout",
+        ":sampler",
+        "//xrtl/base:array_view",
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "sampler",
+    hdrs = ["sampler.h"],
+    deps = [
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "shader_module",
+    hdrs = ["shader_module.h"],
+    deps = [
+        "//xrtl/base:ref_ptr",
+    ],
+)
+
+cc_library(
+    name = "swap_chain",
+    hdrs = ["swap_chain.h"],
+    deps = [
+        ":command_buffer",
+        ":framebuffer",
+        ":pixel_format",
+        ":queue_fence",
+        "//xrtl/base:geometry",
+        "//xrtl/base:ref_ptr",
+    ],
 )

--- a/xrtl/gfx/buffer.h
+++ b/xrtl/gfx/buffer.h
@@ -1,0 +1,80 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_BUFFER_H_
+#define XRTL_GFX_BUFFER_H_
+
+#include "xrtl/gfx/resource.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A buffer resource.
+class Buffer : public Resource {
+ public:
+  // Defines how a buffer is intended to be used.
+  enum class Usage {
+    kNone = 0,
+    // Indicates that the buffer can be used as the source of a transfer
+    // command.
+    kTransferSource = 0x00000001,
+    // Indicates that the buffer can be used as the target of a transfer
+    // command.
+    kTransferTarget = 0x00000002,
+    // Indicates that the buffer can be used in a DescriptorSet as a
+    // kUniformTexelBuffer.
+    //
+    // Uniform texel buffers differ from uniform buffers in that they are
+    // read-only and cached during shader execution as if they were texel
+    // fetches. This means that they only benefit when all threadgroups are
+    // accessing the same areas of the buffer concurrently. If the buffer is
+    // accessed randomly (or by vertex/instance ID) use a kUniformBuffer
+    // instead.
+    kUniformTexelBuffer = 0x00000004,
+    // Indicates that the buffer can be used in a DescriptorSet as a
+    // kStorageTexelBuffer.
+    kStorageTexelBuffer = 0x00000008,
+    // Indicates that the buffer can be used in a DescriptorSet as a
+    // kUniformBuffer.
+    kUniformBuffer = 0x00000010,
+    // Indicates that the buffer can be used in a DescriptorSet as a
+    // kStorageBuffer.
+    kStorageBuffer = 0x00000020,
+    // Indicates that the buffer can be passed to BindIndexBuffer.
+    kIndexBuffer = 0x00000040,
+    // Indicates that the buffer can be passed to BindVertexBuffer(s).
+    kVertexBuffer = 0x00000080,
+    // Indicates that the buffer can be passed to one of the DrawIndirect
+    // methods.
+    kIndirectBuffer = 0x00000100,
+  };
+
+  ~Buffer() override = default;
+
+  // Bitmask describing how the buffer is to be used.
+  Usage usage_mask() const { return usage_mask_; }
+
+ protected:
+  Buffer(size_t allocation_size, Usage usage_mask)
+      : Resource(allocation_size), usage_mask_(usage_mask) {}
+
+  Usage usage_mask_ = Usage::kNone;
+};
+
+XRTL_BITMASK(Buffer::Usage);
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_BUFFER_H_

--- a/xrtl/gfx/command_buffer.h
+++ b/xrtl/gfx/command_buffer.h
@@ -1,0 +1,160 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_COMMAND_BUFFER_H_
+#define XRTL_GFX_COMMAND_BUFFER_H_
+
+#include "xrtl/base/macros.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/command_encoder.h"
+#include "xrtl/gfx/framebuffer.h"
+#include "xrtl/gfx/render_pass.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A bitmask indicating the kind of queue operations will require.
+enum class OperationQueueMask : uint32_t {
+  kNone = 0,
+  // A queue supporting render operations (such as Draw*).
+  kRender = 1 << 0,
+  // A queue supporting compute operations (such as Dispatch*).
+  kCompute = 1 << 1,
+  // A queue supporting transfer operations (such as CopyBuffer).
+  kTransfer = 1 << 2,
+};
+XRTL_BITMASK(OperationQueueMask);
+
+// Transient single-shot command buffer.
+// Command buffer lifetime is generally:
+//  - Create from Context.
+//  - Record with begin/encode/end one or more command encoders.
+//  - Submit the command buffer on the Context.
+//    (release and recycle)
+//
+// Commands can be recorded until a command buffer is submitted to the context
+// after which time it must not be modified. Multiple command encoders of either
+// the same or different types can be began/ended while recording within a
+// single CommandBuffer. Note that command buffers that use multiple queues may
+// require internal synchronization with barriers or CommandFences.
+//
+// Usage:
+//   // Allocate command buffer for recording.
+//   auto command_buffer = context->CreateCommandBuffer();
+//   // Record transfer commands preparing buffers.
+//   auto transfer_encoder = command_buffer->BeginTransferCommands();
+//   transfer_encoder->FillBuffer(...);
+//   command_buffer->EndTransferCommands(std::move(transfer_encoder));
+//   // Record compute commands that use the buffers.
+//   auto compute_encoder = command_buffer->BeginComputeCommands();
+//   compute_encoder->Dispatch(...);
+//   command_buffer->EndComputeCommands(std::move(compute_encoder));
+//   // Submit the command buffer for execution.
+//   context->Submit(std::move(command_buffer), signal_fence);
+//
+class CommandBuffer : public RefObject<CommandBuffer> {
+ public:
+  virtual ~CommandBuffer() = default;
+
+  // A bitmask indicating on which queue types this command buffer will execute
+  // based on the commands that were encoded into it.
+  OperationQueueMask queue_mask() const { return queue_mask_; }
+
+  // TODO(benvanik): queries and timestamps.
+  // TODO(benvanik): tessellation.
+
+  // Begins encoding transfer commands into the command buffer.
+  // All commands encoded with the returned encoder will be written in order to
+  // the buffer.
+  //
+  // Transfer commands will execute on the transfer queue.
+  //
+  // Only one encoder may be active at a time. When done encoding callers must
+  // give the encoder back to the command buffer with EndTransferCommands.
+  // Encoders are not thread-safe.
+  //
+  // Usage:
+  //  auto encoder = command_buffer->BeginTransferCommands();
+  //  encoder->FillBuffer(...);
+  //  command_buffer->EndTransferCommands(std::move(encoder));
+  virtual TransferCommandEncoderPtr BeginTransferCommands() = 0;
+  virtual void EndTransferCommands(TransferCommandEncoderPtr encoder) = 0;
+
+  // Begins encoding compute commands into the command buffer.
+  // All commands encoded with the returned encoder will be written in order to
+  // the buffer.
+  //
+  // Compute commands will execute on the compute and/or transfer queues.
+  //
+  // Only one encoder may be active at a time. When done encoding callers must
+  // give the encoder back to the command buffer with EndComputeCommands.
+  // Encoders are not thread-safe.
+  //
+  // Usage:
+  //  auto encoder = command_buffer->BeginComputeCommands();
+  //  encoder->Dispatch(...);
+  //  command_buffer->EndComputeCommands(std::move(encoder));
+  virtual ComputeCommandEncoderPtr BeginComputeCommands() = 0;
+  virtual void EndComputeCommands(ComputeCommandEncoderPtr encoder) = 0;
+
+  // Begins encoding render commands into the command buffer.
+  // All commands encoded with the returned encoder will be written in order to
+  // the buffer.
+  //
+  // Render commands will execute on the render and/or transfer queues.
+  //
+  // Only one encoder may be active at a time. When done encoding callers must
+  // give the encoder back to the command buffer with EndRenderCommands.
+  // Encoders are not thread-safe.
+  //
+  // Usage:
+  //  auto encoder = command_buffer->BeginRenderCommands();
+  //  encoder->ResolveImage(...);
+  //  command_buffer->EndRenderCommands(std::move(encoder));
+  virtual RenderCommandEncoderPtr BeginRenderCommands() = 0;
+  virtual void EndRenderCommands(RenderCommandEncoderPtr encoder) = 0;
+
+  // Begins a render pass and encoding commands into the command buffer.
+  // All commands encoded with the returned encoder will be written in order to
+  // the buffer.
+  //
+  // The render pass begins in the first defined subpass. Use NextSubPass to
+  // advance to the next subpass until all subpasses have been populated.
+  //
+  // Render pass commands will execute on the render queue.
+  //
+  // Only one encoder may be active at a time. When done encoding callers must
+  // give the encoder back to the command buffer with EndRenderPass.
+  // Encoders are not thread-safe.
+  //
+  // Usage:
+  //  auto encoder = command_buffer->BeginRenderPass(render_pass, framebuffer);
+  //  encoder->Draw(...);
+  //  encoder->NextSubPass();
+  //  encoder->Draw(...);
+  //  command_buffer->EndRenderPass(std::move(encoder));
+  virtual RenderPassCommandEncoderPtr BeginRenderPass(
+      ref_ptr<RenderPass> render_pass, ref_ptr<Framebuffer> framebuffer) = 0;
+  virtual void EndRenderPass(RenderPassCommandEncoderPtr encoder) = 0;
+
+ protected:
+  CommandBuffer();
+
+  OperationQueueMask queue_mask_ = OperationQueueMask::kNone;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_COMMAND_BUFFER_H_

--- a/xrtl/gfx/command_encoder.h
+++ b/xrtl/gfx/command_encoder.h
@@ -1,0 +1,706 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_COMMAND_ENCODER_H_
+#define XRTL_GFX_COMMAND_ENCODER_H_
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "xrtl/base/array_view.h"
+#include "xrtl/base/logging.h"
+#include "xrtl/base/macros.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/buffer.h"
+#include "xrtl/gfx/command_fence.h"
+#include "xrtl/gfx/image.h"
+#include "xrtl/gfx/pipeline.h"
+#include "xrtl/gfx/pipeline_layout.h"
+#include "xrtl/gfx/resource_set.h"
+#include "xrtl/gfx/sampler.h"
+
+namespace xrtl {
+namespace gfx {
+
+class CommandBuffer;
+
+// A bitmask specifying the set of stencil state for which to update.
+enum class StencilFaceFlag : uint32_t {
+  // Indicates that only the front set of stencil state is updated.
+  kFaceFront = 1 << 0,
+  // Indicates that only the back set of stencil state is updated.
+  kFaceBack = 1 << 1,
+  // Indicates that both sets of stencil state are updated.
+  kFrontAndBack = kFaceFront | kFaceBack,
+};
+XRTL_BITMASK(StencilFaceFlag);
+
+// Defines a buffer copy region.
+struct CopyBufferRegion {
+  size_t source_offset = 0;
+  size_t target_offset = 0;
+  size_t length = 0;
+};
+
+// Defines an image copy region.
+struct CopyImageRegion {
+  Image::LayerRange source_layer_range;
+  Point3D source_offset;
+  Image::LayerRange target_layer_range;
+  Point3D target_offset;
+  Size3D size;
+};
+
+// Defines a buffer-image copy region.
+struct CopyBufferImageRegion {
+  size_t buffer_offset;
+  int buffer_row_length;
+  int buffer_image_height;
+  Image::LayerRange image_layer_range;
+  Rect3D image_rect;
+};
+
+// Defines an image blit source and target region.
+struct BlitImageRegion {
+  Image::LayerRange source_layer_range;
+  Rect3D source_rect;
+  Image::LayerRange target_layer_range;
+  Rect3D target_rect;
+};
+
+// Defines a clear rectangle.
+struct ClearRect {
+  // 2D region to be cleared.
+  Rect2D rect;
+  // Starting layer index to clear.
+  int base_layer = 0;
+  // Total number of layers to clear.
+  int layer_count = 0;
+};
+
+// Defines a fixed-function viewport.
+struct Viewport {
+  float x = 0.0f;
+  float y = 0.0f;
+  float width = 0.0f;
+  float height = 0.0f;
+  float min_depth = 0.0f;
+  float max_depth = 1.0f;
+
+  Viewport() = default;
+  Viewport(float x, float y, float width, float height)
+      : x(x), y(y), width(width), height(height) {}
+};
+
+// Defines the index buffer element type size.
+enum class IndexElementType {
+  // Unsigned 16-bit integer indices.
+  // When primitive restart is enabled the index 0xFFFF is reserved.
+  kUint16,
+  // Unsigned 32-bit integer indices.
+  // When primitive restart is enabled the index 0xFFFFFFFF is reserved.
+  kUint32,
+};
+
+// Base command encoder.
+// See one of the specific encoders for more information.
+class CommandEncoder {
+ public:
+  // The command buffer the encoder is encoding into.
+  CommandBuffer* command_buffer() const { return command_buffer_; }
+
+  // Inserts a dependency between two stages of the pipeline.
+  // This will split commands encoded into the command buffer based on where in
+  // the stages they fall. Ordering is always preserved. All commands executed
+  // in the source stages are guaranteed to complete before any commands in the
+  // target stages execute.
+  //
+  // Queue: any.
+  virtual void PipelineBarrier(PipelineStageFlag source_stage_mask,
+                               PipelineStageFlag target_stage_mask,
+                               PipelineDependencyFlag dependency_flags) = 0;
+
+  // Inserts a memory dependency between two stages of the pipeline.
+  // Memory accesses using the set of access types in source_access_mask
+  // performed in pipeline stages in source_stage_mask by the first set of
+  // commands must complete and be available to later commands. The side effects
+  // of the first set of commands will be visible to memory accesses using the
+  // set of access types in target_access_mask performed in pipeline stages in
+  // target_stage_mask by the second set of commands.
+  //
+  // If the barrier is framebuffer-local these requirements only apply to
+  // invocations within the same framebuffer-space region and for pipeline
+  // stages that perform framebuffer-space work.
+  //
+  // The execution dependency guarantees that execution of work by the
+  // destination stages of the second set of commands will not begin until
+  // execution of work by the source stages of the first set of commands has
+  // completed.
+  //
+  // Queue: any.
+  virtual void MemoryBarrier(PipelineStageFlag source_stage_mask,
+                             PipelineStageFlag target_stage_mask,
+                             PipelineDependencyFlag dependency_flags,
+                             AccessFlag source_access_mask,
+                             AccessFlag target_access_mask) = 0;
+
+  // Inserts a memory dependency between two stages of the pipeline.
+  // This type of barrier only applies to memory accesses involving a specific
+  // range of the specified buffer object. That is, a memory dependency formed
+  // from a buffer memory barrier is scoped to the specified range of the
+  // buffer.
+  //
+  // Queue: any.
+  virtual void BufferBarrier(PipelineStageFlag source_stage_mask,
+                             PipelineStageFlag target_stage_mask,
+                             PipelineDependencyFlag dependency_flags,
+                             AccessFlag source_access_mask,
+                             AccessFlag target_access_mask,
+                             ref_ptr<Buffer> buffer, size_t offset,
+                             size_t length) = 0;
+  void BufferBarrier(PipelineStageFlag source_stage_mask,
+                     PipelineStageFlag target_stage_mask,
+                     PipelineDependencyFlag dependency_flags,
+                     AccessFlag source_access_mask,
+                     AccessFlag target_access_mask, ref_ptr<Buffer> buffer) {
+    BufferBarrier(source_stage_mask, target_stage_mask, dependency_flags,
+                  source_access_mask, target_access_mask, buffer, 0,
+                  buffer->allocation_size());
+  }
+
+  // TODO(benvanik): image regions.
+  // Inserts a memory dependency between two stages of the pipeline.
+  // This type of barrier only applies to memory accesses involving a specific
+  // image subresource range of the specified image object. That is, a
+  // memory dependency formed from an image memory barrier is scoped to the
+  // specified image subresources of the image. It is also used to perform a
+  // layout transition for an image subresource range.
+  //
+  // source_layout may be Layout::kUndefined if it is not known. target_layout
+  // must not be Layout::kUndefined.
+  //
+  // Queue: any.
+  virtual void ImageBarrier(PipelineStageFlag source_stage_mask,
+                            PipelineStageFlag target_stage_mask,
+                            PipelineDependencyFlag dependency_flags,
+                            AccessFlag source_access_mask,
+                            AccessFlag target_access_mask,
+                            Image::Layout source_layout,
+                            Image::Layout target_layout, ref_ptr<Image> image,
+                            Image::LayerRange layer_range) = 0;
+  void ImageBarrier(PipelineStageFlag source_stage_mask,
+                    PipelineStageFlag target_stage_mask,
+                    PipelineDependencyFlag dependency_flags,
+                    AccessFlag source_access_mask,
+                    AccessFlag target_access_mask, Image::Layout source_layout,
+                    Image::Layout target_layout, ref_ptr<Image> image) {
+    ImageBarrier(source_stage_mask, target_stage_mask, dependency_flags,
+                 source_access_mask, target_access_mask, source_layout,
+                 target_layout, image, image->entire_range());
+  }
+
+  // TODO(benvanik): API for transfering queue ownership to enable multi-queue.
+  // virtual void TransferBufferQueue(...) = 0;
+  // virtual void TransferImageQueue(...) = 0;
+
+ protected:
+  explicit CommandEncoder(CommandBuffer* command_buffer)
+      : command_buffer_(command_buffer) {}
+
+  CommandBuffer* command_buffer_ = nullptr;
+};
+
+// Command encoder for transfer commands.
+// Transfer commands deal with manipulating buffers and images in a way that
+// can often run in parallel with compute and render commands. Transfer commands
+// cannot perform any format conversion or work with data that may be packed in
+// a device-specific format (so clearing depth buffers isn't possible).
+class TransferCommandEncoder : public CommandEncoder {
+ public:
+  // Fills a buffer with a repeating data value.
+  // This can be used to quickly clear a buffer.
+  // The size passed must be 4-byte aligned. If it is not aligned then the size
+  // will be rounded down to the next smallest 4-byte interval.
+  //
+  // Queue: transfer.
+  // Stage: transfer.
+  //
+  // target_buffer must have Usage::kTransferTarget.
+  virtual void FillBuffer(ref_ptr<Buffer> buffer, size_t offset, size_t length,
+                          uint8_t value) = 0;
+
+  // Updates buffer contents inline from the command buffer.
+  // This can be faster (and significantly easier) for updating small buffers,
+  // though it should be used sparingly as to not bloat command buffers.
+  // The data size is limited to 65536 bytes (64k). For larger updates use real
+  // buffer upload techniques like MapMemory or staging buffers.
+  //
+  // Queue: transfer.
+  // Stage: transfer.
+  //
+  // target_buffer must have Usage::kTransferTarget.
+  virtual void UpdateBuffer(ref_ptr<Buffer> target_buffer, size_t target_offset,
+                            const void* source_data,
+                            size_t source_data_length) = 0;
+  void UpdateBuffer(ref_ptr<Buffer> target_buffer, size_t target_offset,
+                    std::vector<uint8_t> source_data) {
+    return UpdateBuffer(std::move(target_buffer), target_offset,
+                        source_data.data(), source_data.size());
+  }
+  void UpdateBuffer(ref_ptr<Buffer> target_buffer, size_t target_offset,
+                    std::vector<uint8_t> source_data, size_t source_data_offset,
+                    size_t source_data_length) {
+    return UpdateBuffer(std::move(target_buffer), target_offset,
+                        source_data.data() + source_data_offset,
+                        source_data_length);
+  }
+
+  // Copies data from one buffer to another.
+  // The source and target buffer may be the same (alias), but just as with
+  // memcpy the regions must not overlap.
+  //
+  // Queue: transfer.
+  // Stage: transfer.
+  //
+  // source_buffer must have Usage::kTransferSource.
+  // target_buffer must have Usage::kTransferTarget.
+  virtual void CopyBuffer(ref_ptr<Buffer> source_buffer,
+                          ref_ptr<Buffer> target_buffer,
+                          ArrayView<CopyBufferRegion> regions) = 0;
+
+  // Copies data between two images without performing conversion.
+  // This is effectively a memcpy, and as such cannot scale/resize/convert the
+  // image contents. The source and target images may be the same (alias),
+  // but just as with memcpy the regions must not overlap.
+  //
+  // The source and target images must be either the same format or a
+  // compatible format. Formats are compatible if their element size is the same
+  // (such as kR8G8B8A8 and kR32, which are both 4-byte elements). Depth/stencil
+  // formats must match exactly.
+  //
+  // When copying to/from or between compressed formats the extents provided
+  // in the regions must be multiples of the compressed texel block sizes.
+  //
+  // For more details see vkCmdCopyImage:
+  // https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkCmdCopyImage.html
+  //
+  // Queue: transfer.
+  // Stage: transfer.
+  //
+  // source_image must have Usage::kTransferSource.
+  // source_image_layout must be kGeneral or kTransferSourceOptimal.
+  // target_image must have Usage::kTransferTarget.
+  // target_image_layout must be kGeneral or kTransferTargetOptimal.
+  virtual void CopyImage(ref_ptr<Image> source_image,
+                         Image::Layout source_image_layout,
+                         ref_ptr<Image> target_image,
+                         Image::Layout target_image_layout,
+                         ArrayView<CopyImageRegion> regions) = 0;
+
+  // Copies data from a buffer to an image.
+  //
+  // Queue: transfer.
+  // Stage: transfer.
+  //
+  // source_buffer must have Usage::kTransferSource.
+  // target_image must have Usage::kTransferTarget.
+  // target_image_layout must be kGeneral or kTransferTargetOptimal.
+  virtual void CopyBufferToImage(ref_ptr<Buffer> source_buffer,
+                                 ref_ptr<Image> target_image,
+                                 Image::Layout target_image_layout,
+                                 ArrayView<CopyBufferImageRegion> regions) = 0;
+
+  // Copies data from an image to a buffer.
+  //
+  // Queue: transfer.
+  // Stage: transfer.
+  //
+  // source_image must have Usage::kTransferSource.
+  // source_image_layout must be kGeneral or kTransferSourceOptimal.
+  // target_buffer must have Usage::kTransferTarget.
+  virtual void CopyImageToBuffer(ref_ptr<Image> source_image,
+                                 Image::Layout source_image_layout,
+                                 ref_ptr<Buffer> target_buffer,
+                                 ArrayView<CopyBufferImageRegion> regions) = 0;
+
+ protected:
+  explicit TransferCommandEncoder(CommandBuffer* command_buffer)
+      : CommandEncoder(command_buffer) {}
+};
+
+using TransferCommandEncoderPtr =
+    std::unique_ptr<TransferCommandEncoder, void (*)(TransferCommandEncoder*)>;
+
+// Command encoder for compute commands.
+// Everything required to fully execute compute pipelines can be encoded here.
+// Compute commands may be able to run on their own queue in parallel with
+// transfer or render commands.
+//
+// Some platforms may not support compute pipelines and they should be feature
+// detected before attempting to encode command buffers with them.
+class ComputeCommandEncoder : public TransferCommandEncoder {
+ public:
+  // Sets a command fence to signaled state.
+  // The fence will be signaled after all commands previously encoded that
+  // affect the given stages complete.
+  // Fences may only be signaled once and repeated SetFence calls will be
+  // no-ops.
+  virtual void SetFence(ref_ptr<CommandFence> fence,
+                        PipelineStageFlag pipeline_stage_mask) = 0;
+
+  // Resets a fence object to non-signaled state.
+  // The fence will be reset after all commands previously encoded that affect
+  // the given stages complete.
+  // Fences may only be reset once and repeated ResetFence calls will be no-ops.
+  virtual void ResetFence(ref_ptr<CommandFence> fence,
+                          PipelineStageFlag pipeline_stage_mask) = 0;
+
+  // Waits for the given fence to be signaled.
+  // If it is already signaled the wait will continue immediately.
+  // This is usually followed by one or more barriers to ensure memory safety.
+  virtual void WaitFences(ArrayView<ref_ptr<CommandFence>> fences) = 0;
+  void WaitFence(ref_ptr<CommandFence> fence) { WaitFences({fence}); }
+
+  // Clears regions of a color image.
+  //
+  // Queue: compute.
+  //
+  // image must have Usage::kTransferTarget.
+  // image_layout must be kGeneral or kTransferTargetOptimal.
+  virtual void ClearColorImage(ref_ptr<Image> image, Image::Layout image_layout,
+                               float color_value[4],
+                               ArrayView<Image::LayerRange> ranges) = 0;
+  virtual void ClearColorImage(ref_ptr<Image> image, Image::Layout image_layout,
+                               uint32_t color_value[4],
+                               ArrayView<Image::LayerRange> ranges) = 0;
+
+  // Binds a pipeline object to a command buffer.
+  // All future compute dispatches will use this pipeline until another is
+  // bound.
+  //
+  // Queue: compute.
+  virtual void BindPipeline(ref_ptr<ComputePipeline> pipeline) = 0;
+
+  // Binds a pipeline binding set to a command buffer.
+  // All future compute dispatches will use the bound set.
+  //
+  // Queue: compute.
+  virtual void BindResourceSet(ref_ptr<ResourceSet> resource_set,
+                               ArrayView<size_t> dynamic_offsets) = 0;
+  void BindResourceSet(ref_ptr<ResourceSet> resource_set) {
+    BindResourceSet(std::move(resource_set), {});
+  }
+
+  // Updates the values of push constants.
+  // The stage_mask specifies which shader stages will use the updated values.
+  //
+  // Queue: compute.
+  virtual void PushConstants(ref_ptr<PipelineLayout> pipeline_layout,
+                             ShaderStageFlag stage_mask, size_t offset,
+                             size_t length, const void* data) = 0;
+
+  // Dispatches compute work items.
+  // The maximum group counts are specified in Device::Limits.
+  //
+  // Queue: compute.
+  virtual void Dispatch(int group_count_x, int group_count_y,
+                        int group_count_z) = 0;
+
+  // Dispatchs compute work items using indirect parameters.
+  //
+  // Queue: compute.
+  virtual void DispatchIndirect(ref_ptr<Buffer> buffer, size_t offset) = 0;
+
+ protected:
+  explicit ComputeCommandEncoder(CommandBuffer* command_buffer)
+      : TransferCommandEncoder(command_buffer) {}
+};
+
+using ComputeCommandEncoderPtr =
+    std::unique_ptr<ComputeCommandEncoder, void (*)(ComputeCommandEncoder*)>;
+
+// Command encoder for generic render commands.
+// These commands run on the render queue but happen outside of a render pass.
+// For commands related to drawing see the RenderPassCommandEncoder which
+// encodes drawing-specific commands.
+class RenderCommandEncoder : public TransferCommandEncoder {
+ public:
+  // Sets a command fence to signaled state.
+  // The fence will be signaled after all commands previously encoded that
+  // affect the given stages complete.
+  // Fences may only be signaled once and repeated SetFence calls will be
+  // no-ops.
+  virtual void SetFence(ref_ptr<CommandFence> fence,
+                        PipelineStageFlag pipeline_stage_mask) = 0;
+
+  // Resets a fence object to non-signaled state.
+  // The fence will be reset after all commands previously encoded that affect
+  // the given stages complete.
+  // Fences may only be reset once and repeated ResetFence calls will be no-ops.
+  virtual void ResetFence(ref_ptr<CommandFence> fence,
+                          PipelineStageFlag pipeline_stage_mask) = 0;
+
+  // Waits for the given fence to be signaled.
+  // If it is already signaled the wait will continue immediately.
+  // This is usually followed by one or more barriers to ensure memory safety.
+  virtual void WaitFences(ArrayView<ref_ptr<CommandFence>> fences) = 0;
+  void WaitFence(ref_ptr<CommandFence> fence) { WaitFences({fence}); }
+
+  // Clears regions of a color image.
+  //
+  // Queue: render.
+  //
+  // image must have Usage::kTransferTarget.
+  // image_layout must be kGeneral or kTransferTargetOptimal.
+  virtual void ClearColorImage(ref_ptr<Image> image, Image::Layout image_layout,
+                               float color_value[4],
+                               ArrayView<Image::LayerRange> ranges) = 0;
+  virtual void ClearColorImage(ref_ptr<Image> image, Image::Layout image_layout,
+                               uint32_t color_value[4],
+                               ArrayView<Image::LayerRange> ranges) = 0;
+
+  // Fills regions of a combined depth/stencil image.
+  //
+  // Queue: render.
+  //
+  // image must have Usage::kTransferTarget.
+  // image_layout must be kGeneral or kTransferTargetOptimal.
+  virtual void ClearDepthStencilImage(ref_ptr<Image> image,
+                                      Image::Layout image_layout,
+                                      float depth_value, uint32_t stencil_value,
+                                      ArrayView<Image::LayerRange> ranges) = 0;
+
+  // Copies regions of an image potentially performing format conversion.
+  // There are tons of restrictions on this. See the reference.
+  //
+  // For more details see vkCmdBlitImage:
+  // https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkCmdBlitImage.html
+  //
+  // Queue: render.
+  //
+  // source_image must have Usage::kTransferSource.
+  // source_image_layout must be kGeneral or kTransferSourceOptimal.
+  // target_image must have Usage::kTransferTarget.
+  // target_image_layout must be kGeneral or kTransferTargetOptimal.
+  virtual void BlitImage(ref_ptr<Image> source_image,
+                         Image::Layout source_image_layout,
+                         ref_ptr<Image> target_image,
+                         Image::Layout target_image_layout,
+                         Sampler::Filter scaling_filter,
+                         ArrayView<BlitImageRegion> regions) = 0;
+
+  // Resolves regions of a multisample image to a non-multisample image.
+  //
+  // Queue: render.
+  //
+  // source_image_layout must be kGeneral or kTransferSourceOptimal.
+  // target_image_layout must be kGeneral or kTransferTargetOptimal.
+  virtual void ResolveImage(ref_ptr<Image> source_image,
+                            Image::Layout source_image_layout,
+                            ref_ptr<Image> target_image,
+                            Image::Layout target_image_layout,
+                            ArrayView<CopyImageRegion> regions) = 0;
+
+  // TODO(benvanik): specify layer range?
+  // Generates mipmaps for the given image.
+  // Mip level 0 will be used to populate the entire mip chain for all layers.
+  // The image must have been created with mip levels. Existing contents will
+  // be overwritten.
+  //
+  // Queue: render.
+  //
+  // TODO(benvanik): restrictions on layout/usage.
+  virtual void GenerateMipmaps(ref_ptr<Image> image) = 0;
+
+ protected:
+  explicit RenderCommandEncoder(CommandBuffer* command_buffer)
+      : TransferCommandEncoder(command_buffer) {}
+};
+
+using RenderCommandEncoderPtr =
+    std::unique_ptr<RenderCommandEncoder, void (*)(RenderCommandEncoder*)>;
+
+// Command encoder for render passes.
+// All encoded commands are performed within the context of the render pass that
+// was used to create the encoder. If the render pass contains multiple
+// subpasses the NextSubpass method must be used to advance through all of them
+// during encoding.
+class RenderPassCommandEncoder : public CommandEncoder {
+ public:
+  // Waits for the given fence to be signaled.
+  // If it is already signaled the wait will continue immediately.
+  // This is usually followed by one or more barriers to ensure memory safety.
+  virtual void WaitFences(ArrayView<ref_ptr<CommandFence>> fences) = 0;
+  void WaitFence(ref_ptr<CommandFence> fence) { WaitFences({fence}); }
+
+  // Clears one or more regions of color attachments inside a render pass.
+  // The attachment must be active in the current subpass.
+  //
+  // Queue: render.
+  virtual void ClearColorAttachment(int color_attachment_index,
+                                    float color_value[4],
+                                    ArrayView<ClearRect> clear_rects) = 0;
+  virtual void ClearColorAttachment(int color_attachment_index,
+                                    uint32_t color_value[4],
+                                    ArrayView<ClearRect> clear_rects) = 0;
+
+  // Clears one or more regions of a depth/stencil attachment inside a render
+  // pass. The current subpass must have a depth/stencil attachment.
+  //
+  // Queue: render.
+  virtual void ClearDepthStencilAttachment(
+      float depth_value, uint32_t stencil_value,
+      ArrayView<ClearRect> clear_rects) = 0;
+
+  // Transitions to the next sub pass in the render pass.
+  //
+  // Queue: render.
+  virtual void NextSubpass() = 0;
+
+  // Sets the dynamic scissor rectangles on a command buffer.
+  //
+  // Queue: render
+  virtual void SetScissor(int first_scissor, ArrayView<Rect2D> scissors) = 0;
+
+  // Sets the viewports on a command buffer.
+  //
+  // Queue: render.
+  virtual void SetViewports(int first_viewport,
+                            ArrayView<Viewport> viewports) = 0;
+  void SetViewport(Viewport viewport) { SetViewports(0, {viewport}); }
+
+  // Sets the dynamic line width state.
+  //
+  // Queue: render
+  virtual void SetLineWidth(float line_width) = 0;
+
+  // Sets the depth bias dynamic state.
+  //
+  // Queue: render
+  virtual void SetDepthBias(float depth_bias_constant_factor,
+                            float depth_bias_clamp,
+                            float depth_bias_slope_factor) = 0;
+
+  // Sets the depth bounds test values for a command buffer.
+  //
+  // Queue: render
+  virtual void SetDepthBounds(float min_depth_bounds,
+                              float max_depth_bounds) = 0;
+
+  // Sets the stencil compare mask dynamic state.
+  //
+  // Queue: render
+  virtual void SetStencilCompareMask(StencilFaceFlag face_mask,
+                                     uint32_t compare_mask) = 0;
+
+  // Sets the stencil write mask dynamic state.
+  //
+  // Queue: render
+  virtual void SetStencilWriteMask(StencilFaceFlag face_mask,
+                                   uint32_t write_mask) = 0;
+
+  // Sets the stencil reference dynamic state.
+  //
+  // Queue: render
+  virtual void SetStencilReference(StencilFaceFlag face_mask,
+                                   uint32_t reference) = 0;
+
+  // Sets the values of blend constants.
+  //
+  // Queue: render
+  virtual void SetBlendConstants(const float blend_constants[4]) = 0;
+
+  // Binds a pipeline object to a command buffer.
+  // All future draws will use this pipeline until another is bound.
+  //
+  // Queue: render.
+  virtual void BindPipeline(ref_ptr<RenderPipeline> pipeline) = 0;
+
+  // Binds a pipeline binding set to a command buffer.
+  // All future draws will use the bound set.
+  //
+  // Queue: render.
+  virtual void BindResourceSet(ref_ptr<ResourceSet> resource_set,
+                               ArrayView<size_t> dynamic_offsets) = 0;
+  void BindResourceSet(ref_ptr<ResourceSet> resource_set) {
+    BindResourceSet(std::move(resource_set), {});
+  }
+
+  // Updates the values of push constants.
+  // The stage_mask specifies which shader stages will use the updated values.
+  //
+  // Queue: render.
+  virtual void PushConstants(ref_ptr<PipelineLayout> pipeline_layout,
+                             ShaderStageFlag stage_mask, size_t offset,
+                             const void* data, size_t data_length) = 0;
+
+  // Binds vertex buffers to a command buffer.
+  //
+  // Queue: render.
+  virtual void BindVertexBuffers(int first_binding,
+                                 ArrayView<ref_ptr<Buffer>> buffers) = 0;
+  virtual void BindVertexBuffers(
+      int first_binding,
+      ArrayView<std::pair<ref_ptr<Buffer>, size_t>> buffers) = 0;
+
+  // Binds an index buffer to a command buffer.
+  //
+  // Queue: render.
+  virtual void BindIndexBuffer(ref_ptr<Buffer> buffer, size_t buffer_offset,
+                               IndexElementType index_type) = 0;
+
+  // Issues a non-indexed draw into a command buffer.
+  //
+  // Queue: render.
+  virtual void Draw(int vertex_count, int instance_count, int first_vertex,
+                    int first_instance) = 0;
+  void Draw(int vertex_count) { Draw(vertex_count, 1, 0, 0); }
+
+  // Issues an indexed draw into a command buffer.
+  //
+  // Queue: render.
+  virtual void DrawIndexed(int index_count, int instance_count, int first_index,
+                           int vertex_offset, int first_instance) = 0;
+  void DrawIndexed(int index_count) { DrawIndexed(index_count, 1, 0, 0, 0); }
+
+  // Issues an indirect non-indexed draw into a command buffer.
+  // draw_count parameter sets are read from the buffer and issued.
+  // stride is the distance between successive sets of draw parameters.
+  //
+  // Queue: render.
+  virtual void DrawIndirect(ref_ptr<Buffer> buffer, size_t buffer_offset,
+                            int draw_count, size_t stride) = 0;
+
+  // Issues an indirect indexed draw into a command buffer.
+  // draw_count parameter sets are read from the buffer and issued.
+  // stride is the distance between successive sets of draw parameters.
+  //
+  // Queue: render.
+  virtual void DrawIndexedIndirect(ref_ptr<Buffer> buffer, size_t buffer_offset,
+                                   int draw_count, size_t stride) = 0;
+
+ protected:
+  explicit RenderPassCommandEncoder(CommandBuffer* command_buffer)
+      : CommandEncoder(command_buffer) {}
+};
+
+using RenderPassCommandEncoderPtr =
+    std::unique_ptr<RenderPassCommandEncoder,
+                    void (*)(RenderPassCommandEncoder*)>;
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_COMMAND_ENCODER_H_

--- a/xrtl/gfx/command_fence.h
+++ b/xrtl/gfx/command_fence.h
@@ -1,0 +1,41 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_COMMAND_FENCE_H_
+#define XRTL_GFX_COMMAND_FENCE_H_
+
+#include "xrtl/base/ref_ptr.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A fence that orders commands within a command buffer.
+// These may be signaled once per object. Attempting to signal an already-
+// signaled fence may produce undefined results.
+//
+// These are device-side only and are only used to order the way commands
+// are processed within command buffers. They cannot be used for synchronization
+// with the CPU (use Context::WaitUntilQueuesIdle for that).
+class CommandFence : public RefObject<CommandFence> {
+ public:
+  virtual ~CommandFence() = default;
+
+ protected:
+  CommandFence() = default;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_COMMAND_FENCE_H_

--- a/xrtl/gfx/context.h
+++ b/xrtl/gfx/context.h
@@ -1,0 +1,270 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_CONTEXT_H_
+#define XRTL_GFX_CONTEXT_H_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "xrtl/base/array_view.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/base/threading/event.h"
+#include "xrtl/gfx/command_buffer.h"
+#include "xrtl/gfx/command_fence.h"
+#include "xrtl/gfx/device.h"
+#include "xrtl/gfx/framebuffer.h"
+#include "xrtl/gfx/image_view.h"
+#include "xrtl/gfx/memory_pool.h"
+#include "xrtl/gfx/pipeline.h"
+#include "xrtl/gfx/pipeline_layout.h"
+#include "xrtl/gfx/pixel_format.h"
+#include "xrtl/gfx/queue_fence.h"
+#include "xrtl/gfx/render_pass.h"
+#include "xrtl/gfx/resource_set.h"
+#include "xrtl/gfx/sampler.h"
+#include "xrtl/gfx/shader_module.h"
+#include "xrtl/gfx/swap_chain.h"
+#include "xrtl/ui/control.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A device (or multi-device) context.
+// This is the primary interface used to allocate resources and manage command
+// queues.
+//
+// Context operations (such as creation) are thread-safe as are the queues
+// maintained by the context. The contents of the resources created must be
+// synchronized by the application using barriers and external locks.
+//
+// Most objects created by the context are pooled, such as fences and command
+// buffers. Always release references to them as soon as they are done to ensure
+// they can be reused by other code.
+class Context : public RefObject<Context> {
+ public:
+  virtual ~Context() = default;
+
+  // The devices that are in use by the context.
+  const std::vector<ref_ptr<Device>>& devices() const { return devices_; }
+
+  // Limits of the device (or devices). Attempting to use values out of these
+  // ranges will result in failures that are difficult to detect so always check
+  // first.
+  const Device::Limits& limits() const { return devices_[0]->limits(); }
+
+  // Enabled device features for use by the context.
+  const Device::Features& features() const { return features_; }
+
+  // Deserializes pipeline cache data from a buffer.
+  // The data provided may be used to initialize the cache, if it is compatible.
+  virtual bool DeserializePipelineCache(const void* existing_data,
+                                        size_t existing_data_length) = 0;
+  bool DeserializePipelineCache(const std::vector<uint8_t>& existing_data) {
+    return DeserializePipelineCache(existing_data.data(), existing_data.size());
+  }
+
+  // Serializes the current pipeline cache data to a buffer.
+  // Applications can save this buffer and use it when recreating the pipeline
+  // cache. If the platform does not support serialization the return will be
+  // empty.
+  virtual std::vector<uint8_t> SerializePipelineCache() = 0;
+
+  // Creates a new queue fence that can be used to synchronize across command
+  // buffer submissions to queues.
+  virtual ref_ptr<QueueFence> CreateQueueFence() = 0;
+  // Creates a new command fence that can be used to order commands within
+  // command buffers.
+  virtual ref_ptr<CommandFence> CreateCommandFence() = 0;
+
+  // Creates a shader module from the data in the specified format.
+  virtual ref_ptr<ShaderModule> CreateShaderModule(
+      ShaderModule::DataFormat data_format, const void* data,
+      size_t data_length) = 0;
+  ref_ptr<ShaderModule> CreateShaderModule(ShaderModule::DataFormat data_format,
+                                           const std::vector<uint8_t>& data) {
+    return CreateShaderModule(data_format, data.data(), data.size());
+  }
+
+  // Creates a pipeline layout.
+  virtual ref_ptr<PipelineLayout> CreatePipelineLayout(
+      ArrayView<PipelineBinding> bindings,
+      ArrayView<PushConstantRange> push_constant_ranges) = 0;
+
+  // Creates a compute pipeline with the given shader.
+  virtual ref_ptr<ComputePipeline> CreateComputePipeline(
+      ref_ptr<PipelineLayout> pipeline_layout,
+      ref_ptr<ShaderModule> shader_module, std::string entry_point) = 0;
+
+  // Creates a render pipeline with the given shaders and parameters.
+  virtual ref_ptr<RenderPipeline> CreateRenderPipeline(
+      ref_ptr<PipelineLayout> pipeline_layout, ref_ptr<RenderPass> render_pass,
+      int render_subpass, RenderState render_state,
+      RenderPipeline::ShaderStages shader_stages) = 0;
+
+  // Creates a binding set used to bind resources to pipelines.
+  // A binding set is only tied to a particular pipeline layout and may be used
+  // with any pipeline sharing that layout.
+  virtual ref_ptr<ResourceSet> CreateResourceSet(
+      ref_ptr<PipelineLayout> pipeline_layout,
+      ArrayView<ResourceSet::Binding> bindings) = 0;
+
+  // Creates a new swap chain using the given control as a display surface.
+  // The present_mode defines how the images are queued for display and
+  // the image_count determines how many images are available for
+  // use. Note that images can be very large and very expensive so it is
+  // a good idea to keep the total count at a minimum (usually 2 for
+  // double-buffering).
+  // Returns nullptr if the given control does not support being a swap chain
+  // target.
+  virtual ref_ptr<SwapChain> CreateSwapChain(
+      ref_ptr<ui::Control> control, SwapChain::PresentMode present_mode,
+      int image_count, ArrayView<PixelFormat> pixel_formats) = 0;
+
+  // Creates a new resource memory pool.
+  // The pool can be used to create images and buffers of the given memory
+  // type.
+  //
+  // The memory pool will request hardware resources in the provided chunk size
+  // and then dole out images and buffers from those chunks. Chunk sizes
+  // should be sufficiently large to prevent frequent exhaustion but not so
+  // large as to potentially run out of device memory. 64-128MB is often a good
+  // size to start with. The provided chunk size may be rounded up to alignment
+  // restrictions of the device.
+  //
+  // Returns nullptr if the memory type mask is invalid.
+  virtual ref_ptr<MemoryPool> CreateMemoryPool(MemoryType memory_type_mask,
+                                               size_t chunk_size) = 0;
+
+  // Creates a new image view referencing an existing image.
+  virtual ref_ptr<ImageView> CreateImageView(ref_ptr<Image> image,
+                                             Image::Type type,
+                                             PixelFormat format,
+                                             Image::LayerRange layer_range) = 0;
+  ref_ptr<ImageView> CreateImageView(ref_ptr<Image> image, Image::Type type,
+                                     PixelFormat format) {
+    return CreateImageView(image, type, format, image->entire_range());
+  }
+
+  // Creates a new image sampler.
+  virtual ref_ptr<Sampler> CreateSampler(Sampler::Params params) = 0;
+
+  // Creates a new render pass.
+  virtual ref_ptr<RenderPass> CreateRenderPass(
+      ArrayView<RenderPass::AttachmentDescription> attachments,
+      ArrayView<RenderPass::SubpassDescription> subpasses,
+      ArrayView<RenderPass::SubpassDependency> subpass_dependencies) = 0;
+
+  // Creates a new framebuffer for the given render pass.
+  // The sizes of the attachments provided must be greater than or equal to
+  // the provided framebuffer size. All attachments must match the render
+  // pass attachment order and formats.
+  //
+  // TODO(benvanik): device limits.
+  virtual ref_ptr<Framebuffer> CreateFramebuffer(
+      ref_ptr<RenderPass> render_pass, Size3D size,
+      ArrayView<ref_ptr<ImageView>> attachments) = 0;
+
+  // Creates a new command buffer.
+  // When submitted the command buffer may be executed in parallel with other
+  // command buffers based on which queues are available on the context devices.
+  // Once submitted a command buffer should be released by the application so
+  // that it may be recycled. Command buffer reuse is not currently supported
+  // and attempting to resubmit a command buffer will result in an error.
+  virtual ref_ptr<CommandBuffer> CreateCommandBuffer() = 0;
+
+  // Defines the return value for command buffer submit operations.
+  enum class SubmitResult {
+    // Submit completed and the command buffers are now queued for execution.
+    // This does not indicate whether they completed executing!
+    kSuccess,
+    // One or more of the command buffers have been submitted multiple times.
+    // This is not currently supported.
+    kCommandBufferReused,
+    // Submit failed because the device had been lost or the submit caused it
+    // to be lost.
+    kDeviceLost,
+  };
+
+  // Submits one or more command buffers for execution on the context.
+  // The command buffers may execute immediately or be queued for execution.
+  // The execution order of command buffers submitted as a batch is in order,
+  // though the commands within the buffers may execute in parallel (especially
+  // likely if they use different queues) from the same submit batch or others.
+  // Always use QueueFences to ensure ordering where required.
+  //
+  // The command buffers will wait to execute until all wait_queue_fences have
+  // be signaled. After the command buffers have completed execution all
+  // provided signal_queue_fences will be signaled.
+  //
+  // The provided signal_handle will be set when the command buffers have
+  // completed execution; only then is it safe to recycle the command buffer.
+  // If the submit call fails immediately due to device loss the signal will not
+  // be set.
+  virtual SubmitResult Submit(
+      ArrayView<ref_ptr<QueueFence>> wait_queue_fences,
+      ArrayView<ref_ptr<CommandBuffer>> command_buffers,
+      ArrayView<ref_ptr<QueueFence>> signal_queue_fences,
+      ref_ptr<Event> signal_handle) = 0;
+  SubmitResult Submit(ref_ptr<CommandBuffer> command_buffer,
+                      ref_ptr<QueueFence> signal_queue_fence) {
+    return Submit({}, {command_buffer}, {signal_queue_fence}, nullptr);
+  }
+  SubmitResult Submit(ref_ptr<QueueFence> wait_queue_fence,
+                      ref_ptr<CommandBuffer> command_buffer,
+                      ref_ptr<QueueFence> signal_queue_fence) {
+    return Submit({wait_queue_fence}, {command_buffer}, {signal_queue_fence},
+                  nullptr);
+  }
+
+  // Defines the return value for queue wait operations.
+  enum class WaitResult {
+    // Wait completed successfully and all command buffers in the specified
+    // queues have completed execution.
+    kSuccess,
+    // Wait failed because the device was lost while waiting.
+    kDeviceLost,
+  };
+
+  // TODO(benvanik): find a way to use a WaitHandle - external fences?
+
+  // Blocks until all queues on all devices are idle.
+  // This is akin to a glFinish and should never be called during sustained
+  // operation - just on major lifetime events (suspend, shutdown, etc).
+  //
+  // Upon successful return all command buffers that were submitted have been
+  // executed and retired. If the wait fails the device may be left in an
+  // indeterminate state (usually the cause of a device loss).
+  virtual WaitResult WaitUntilQueuesIdle() = 0;
+
+  // Blocks until all queues matching the mask are idle.
+  // Upon successful return all command buffers that were submitted to queues
+  // matching the mask will have been executed and retired. If the wait fails
+  // the device may be left in an indeterminate state (usually the cause of a
+  // device loss).
+  virtual WaitResult WaitUntilQueuesIdle(OperationQueueMask queue_mask) = 0;
+
+ protected:
+  Context(std::vector<ref_ptr<Device>> devices, Device::Features features)
+      : devices_(std::move(devices)), features_(std::move(features)) {}
+
+  std::vector<ref_ptr<Device>> devices_;
+  Device::Features features_;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_CONTEXT_H_

--- a/xrtl/gfx/context_factory.cc
+++ b/xrtl/gfx/context_factory.cc
@@ -1,0 +1,79 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xrtl/gfx/context_factory.h"
+
+#include "xrtl/base/flags.h"
+#include "xrtl/base/logging.h"
+
+DEFINE_string(gfx,
+              "Graphics backend used for rendering and compute: "
+              "[nop, es3, metal, vulkan]",
+              "");
+
+namespace xrtl {
+namespace gfx {
+
+// Creates a context factory with the given backend name.
+// Pass empty string to get the default platform backend factory.
+// Returns nullptr if the backend is not compiled in or supported on the
+// current platform.
+//
+// Valid values:
+//   '': platform default, never nop.
+//   'nop': no-op (null) backend; performs no rendering, testing-only.
+//   'es3': OpenGL ES 3.X (Android/Emscripten/Linux/iOS/MacOS/Windows)
+//   'metal': Metal (iOS/MacOS only)
+//   'vulkan': Vulkan (Android/Linux/Windows)
+ref_ptr<ContextFactory> ContextFactory::Create(std::string name) {
+  // Use flag if no name is provided.
+  if (name.empty()) {
+    name = FLAGS_gfx;
+  }
+
+  // Only allow nop when specified explicitly.
+  if (name == "nop") {
+    return nullptr;  // TODO(benvanik): nop.
+  }
+
+  // Build a list of available context types sorted by platform priority.
+  std::vector<std::string> available_types;
+  // TODO(benvanik): #if switch based on defines.
+
+  // Find the desired type.
+  std::string desired_type;
+  if (name.empty()) {
+    // Pick the first available type.
+    desired_type = available_types.front();
+  } else {
+    for (auto available_type : available_types) {
+      if (available_type == name) {
+        desired_type = name;
+        break;
+      }
+    }
+  }
+  if (desired_type.empty()) {
+    // Could not find any type to use.
+    return nullptr;
+  }
+
+  // Create the type.
+  // TODO(benvanik): #if switch based on defines.
+
+  return nullptr;
+}
+
+}  // namespace gfx
+}  // namespace xrtl

--- a/xrtl/gfx/context_factory.h
+++ b/xrtl/gfx/context_factory.h
@@ -1,0 +1,118 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_CONTEXT_FACTORY_H_
+#define XRTL_GFX_CONTEXT_FACTORY_H_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "xrtl/base/array_view.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/context.h"
+#include "xrtl/gfx/device.h"
+
+namespace xrtl {
+namespace gfx {
+
+// Graphics context factory.
+// Factories are implemented per graphics API backend and enable device
+// enumeration and context creation.
+//
+// Usage:
+//  auto factory = CreateContextFactorySomehow();
+//  auto device = factory->default_device();
+//  Device::Features features;
+//  features.foo = true;
+//  ref_ptr<Context> context;
+//  factory->CreateContext(device, features, &context);
+class ContextFactory : public RefObject<ContextFactory> {
+ public:
+  virtual ~ContextFactory() = default;
+
+  // Creates a context factory with the given backend name.
+  // Pass empty string to get the default platform backend factory.
+  // Returns nullptr if the backend is not compiled in or supported on the
+  // current platform.
+  //
+  // Valid values:
+  //   '': platform default or --gfx= flag value, possibly nop.
+  //   'nop': no-op (null) backend; performs no rendering.
+  //   'es3': OpenGL ES 3.X (Android/Emscripten/Linux/iOS/MacOS/Windows)
+  //   'metal': Metal (iOS/MacOS only)
+  //   'vulkan': Vulkan (Android/Linux/Windows)
+  static ref_ptr<ContextFactory> Create(std::string name = "");
+
+  // TODO(benvanik): add API name/version/etc.
+
+  // Returns a list of all devices currently available for use by this API.
+  // Note that not all backends support all devices that may be present in
+  // a system.
+  virtual const std::vector<ref_ptr<Device>>& devices() const = 0;
+
+  // Returns the device that can be used for the best performance on the system.
+  // May return nullptr if there are no devices available for use.
+  // For example on a system with both an integrated and discrete GPU this will
+  // return the discrete one.
+  virtual ref_ptr<Device> default_device() const = 0;
+
+  // Defines the result of a CreateContext operation.
+  enum class CreateResult {
+    // Context was created successfully and is ready for use.
+    kSuccess,
+    // Context could not be created for a reason not covered by the other
+    // errors.
+    kUnknownError,
+    // One or more of the features requested was not available.
+    kUnsupportedFeatures,
+    // The devices provided were not compatible with each other. All devices
+    // must have the same multi-device compatibility group.
+    kIncompatibleDevices,
+    // Driver reported it was out of memory or unable to allocate system
+    // resources.
+    kOutOfMemory,
+    // Device has been lost and may require user intervention (reboot, etc).
+    kDeviceLost,
+  };
+
+  // Creates a new graphics context using the given devices.
+  // All devices specified must be in a multi-device compatibility group as
+  // indicated by multi_device_group_id. The required features provided will be
+  // used to enable context features if supported and otherwise will cause
+  // creation to fail. All requested features must be supported across all
+  // devices.
+  //
+  // Returns a result indicating whether creation succeeded or the reason it
+  // failed. Failures may happen for many reasons and may happen upon creation
+  // with parameters that have previously succeeded (such as if the system is
+  // out of resources).
+  virtual CreateResult CreateContext(ArrayView<ref_ptr<Device>> devices,
+                                     Device::Features required_features,
+                                     ref_ptr<Context>* out_context) = 0;
+  CreateResult CreateContext(ref_ptr<Device> device,
+                             Device::Features required_features,
+                             ref_ptr<Context>* out_context) {
+    return CreateContext(std::array<ref_ptr<Device>, 1>{{device}},
+                         std::move(required_features), out_context);
+  }
+
+ protected:
+  ContextFactory() = default;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_CONTEXT_FACTORY_H_

--- a/xrtl/gfx/context_factory_test.cc
+++ b/xrtl/gfx/context_factory_test.cc
@@ -1,0 +1,29 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xrtl/gfx/context_factory.h"
+
+#include "xrtl/testing/gtest.h"
+
+namespace xrtl {
+namespace gfx {
+namespace {
+
+TEST(ContextFactoryTest, Foo) {
+  //
+}
+
+}  // namespace
+}  // namespace gfx
+}  // namespace xrtl

--- a/xrtl/gfx/device.h
+++ b/xrtl/gfx/device.h
@@ -1,0 +1,158 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_DEVICE_H_
+#define XRTL_GFX_DEVICE_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "xrtl/base/ref_ptr.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A device available for use by the backend graphics API.
+// This may represent a physical device in the system or a logical device as
+// exposed by the API.
+class Device : public RefObject<Device> {
+ public:
+  virtual ~Device() = default;
+
+  // The type of the device.
+  enum class Type {
+    // A CPU (either the primary CPU or some CPU-like accelerator).
+    kCpu,
+    // A virtualized GPU (such as in a virtualization environment).
+    kGpuVirtual,
+    // A GPU embedded or tightly coupled with the primary CPU.
+    kGpuIntegrated,
+    // A GPU separate from from the CPU.
+    kGpuDiscrete,
+    // Something else or unknown.
+    kOther,
+  };
+
+  // TODO(benvanik): flesh this out (comparison operators, is_valid, etc).
+  struct PersistenceId {
+    uint8_t uuid[16];
+
+    // True if the ID is valid and pipelines can be persisted using it as a key.
+    bool is_valid() const {
+      // We don't support persistence yet so always say no.
+      return false;
+    }
+  };
+
+  // Describes the limits of the device.
+  //
+  // Maps to:
+  //  https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkPhysicalDeviceLimits.html
+  struct Limits {
+    // TODO(benvanik): texture sizes, buffer sizes, render-target counts, etc.
+  };
+
+  // Describes the features available for use on the device.
+  // When passed to CreateContext it is used to enable specific features on the
+  // created context.
+  //
+  // Maps to:
+  //  https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkPhysicalDeviceFeatures.html
+  struct Features {
+    // TODO(benvanik): robust buffer access, full draw index uint32, extensions.
+    // TODO(benvanik): render or compute.
+  };
+
+  // Describes a queue family available on the device.
+  // Each queue family supports one or more capabilities and may have one or
+  // more independent queues that can operate in parallel. Each queue within a
+  // family can be retrieved from the Context after creation as a Queue object.
+  //
+  // Maps to:
+  //  https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkQueueFamilyProperties.html
+  struct QueueFamily {
+    // Internal queue family identifier.
+    int queue_family_index = 0;
+    // True if the queues support render operations.
+    bool supports_render = false;
+    // True if the queues support compute operations.
+    bool supports_compute = false;
+    // True if the queues support transfer operations.
+    bool supports_transfer = false;
+    // Total number of queues that may be created from this family.
+    int queue_count = 0;
+    // True if the queue supports timing queries.
+    bool has_timing_support = false;
+  };
+
+  // The type of the device.
+  Type type() const { return type_; }
+  // A vendor-unique identifier (such as '123') or empty string.
+  const std::string& vendor_id() const { return vendor_id_; }
+  // A vendor name (such as 'NVIDIA') or empty string.
+  const std::string& vendor_name() const { return vendor_name_; }
+  // A vendor-specific identifier (such as '123') or empty string.
+  const std::string& device_id() const { return device_id_; }
+  // A vendor-specific device name (such as 'GeForce Blah') or empty string.
+  const std::string& device_name() const { return device_name_; }
+  // A driver version string (such as '1.2.3') or empty string.
+  const std::string& driver_version() const { return driver_version_; }
+
+  // An identifier unique within the ContextFactory that can be used to identify
+  // devices that are compatible with each other and can be used to create a
+  // multi-device context.
+  // For example if device A has ID 1 and device B has ID 2 they are
+  // incompatible and cannot be used together. If both devices shared an ID of 1
+  // they could be used together but a device C with ID 2 could not be.
+  int multi_device_group_id() const { return multi_device_group_id_; }
+
+  // An ID unique to this device and driver version that can be used to match
+  // persisted pipeline caches. It will change when pipelines are not compatible
+  // between versions and must be rebuilt. May return all zeros if the device
+  // does not support caching.
+  const PersistenceId& persistence_id() const { return persistence_id_; }
+
+  // Limits of the device. Attempting to use values out of these ranges will
+  // result in failures that are difficult to detect so always check first.
+  const Limits& limits() const { return limits_; }
+
+  // Available device features for use by the context.
+  const Features& features() const { return features_; }
+
+  // A list of the queue families and capabilities available on the device.
+  const std::vector<QueueFamily>& queue_families() const {
+    return queue_families_;
+  }
+
+ protected:
+  Device() = default;
+
+  Type type_ = Type::kOther;
+  std::string vendor_id_;
+  std::string vendor_name_;
+  std::string device_id_;
+  std::string device_name_;
+  std::string driver_version_;
+  int multi_device_group_id_ = 0;
+  PersistenceId persistence_id_;
+  Limits limits_;
+  Features features_;
+  std::vector<QueueFamily> queue_families_;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_DEVICE_H_

--- a/xrtl/gfx/framebuffer.h
+++ b/xrtl/gfx/framebuffer.h
@@ -1,0 +1,58 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_FRAMEBUFFER_H_
+#define XRTL_GFX_FRAMEBUFFER_H_
+
+#include <utility>
+#include <vector>
+
+#include "xrtl/base/array_view.h"
+#include "xrtl/base/geometry.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/image_view.h"
+#include "xrtl/gfx/render_pass.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A render target framebuffer, composed of one or more attachments.
+class Framebuffer : public RefObject<Framebuffer> {
+ public:
+  virtual ~Framebuffer() = default;
+
+  // Render pass this framebuffer is used with.
+  ref_ptr<RenderPass> render_pass() const { return render_pass_; }
+  // Dimensions of the framebuffer in pixels.
+  Size3D size() const { return size_; }
+  // Attachments for the framebuffer in the same order as specified in the
+  // render pass.
+  std::vector<ref_ptr<ImageView>> attachments() const { return attachments_; }
+
+ protected:
+  Framebuffer(ref_ptr<RenderPass> render_pass, Size3D size,
+              ArrayView<ref_ptr<ImageView>> attachments)
+      : render_pass_(std::move(render_pass)),
+        size_(size),
+        attachments_(attachments) {}
+
+  ref_ptr<RenderPass> render_pass_;
+  Size3D size_;
+  std::vector<ref_ptr<ImageView>> attachments_;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_FRAMEBUFFER_H_

--- a/xrtl/gfx/image.h
+++ b/xrtl/gfx/image.h
@@ -1,0 +1,188 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_IMAGE_H_
+#define XRTL_GFX_IMAGE_H_
+
+#include "xrtl/base/geometry.h"
+#include "xrtl/gfx/render_state.h"
+#include "xrtl/gfx/resource.h"
+
+namespace xrtl {
+namespace gfx {
+
+// An image resource.
+class Image : public Resource {
+ public:
+  // Defines the base type and dimensionality of an image.
+  enum class Type {
+    // A one-dimensional image.
+    k1D,
+    // An array of one-dimensional images.
+    k1DArray,
+    // A two-dimensional image.
+    k2D,
+    // An array of two-dimensional images.
+    k2DArray,
+    // A cube image with six two-dimensional images.
+    //
+    // Layer mapping:
+    //   0: +X
+    //   1: -X
+    //   2: +Y
+    //   3: -Y
+    //   4: +Z
+    //   5: -Z
+    kCube,
+    // A three-dimensional image.
+    k3D,
+  };
+
+  // Defines how an image is intended to be used.
+  enum class Usage {
+    kNone = 0,
+    // Indicates that the image can be used as the source of a transfer
+    // command.
+    kTransferSource = 0x00000001,
+    // Indicates that the image can be used as the target of a transfer
+    // command.
+    kTransferTarget = 0x00000002,
+    // Indicates that the image can be used in a ResourceSet as a
+    // kSampledImage or kCombinedImageSampler.
+    kSampled = 0x00000004,
+    // Indicates that the image can be used in a ResourceSet as a
+    // kStorageImage.
+    kStorage = 0x00000008,
+    // Indicates that the image can be used as an attachment in a Framebuffer.
+    kColorAttachment = 0x00000010,
+    // Indicates that the image can be used as an attachment in a Framebuffer.
+    kDepthStencilAttachment = 0x00000020,
+    // Indicates that the memory bound to this image will have been allocated
+    // with the MemoryType::kLazilyAllocated bit.
+    kTransientAttachment = 0x00000040,
+    // Indicates that the image can be used in a ResourceSet as a
+    // kInputAttachment, be read from a shader as an input attachment, and be
+    // used as an input attachment in a Framebuffer.
+    kInputAttachment = 0x00000080,
+  };
+
+  // Specifies the tiling arrangement of data in an image.
+  enum class TilingMode {
+    // Texels are laid out in an implementation-dependent arrangement for more
+    // optimal memory access.
+    kOptimal = 0,
+    // Texels are laid out in memory in row-major order possibly with some
+    // padding on each row.
+    kLinear = 1,
+  };
+
+  // Layout of the pixel data memory on the device.
+  // Images must be put into a compatible layout before certain operations
+  // are allowed. kGeneral is usually supported, however one of the Optimal
+  // layouts will usually give better performance. Use ImageBarrier to perform
+  // layout transitions.
+  enum class Layout {
+    kUndefined = 0,
+    kGeneral = 1,
+    kColorAttachmentOptimal = 2,
+    kDepthStencilAttachmentOptimal = 3,
+    kDepthStencilReadOnlyOptimal = 4,
+    kShaderReadOnlyOptimal = 5,
+    kTransferSourceOptimal = 6,
+    kTransferTargetOptimal = 7,
+    kPreinitialized = 8,
+    kPresentSource = 1000001002,
+  };
+
+  // Bitmask specifying which aspects of an image are included in a view.
+  enum class AspectFlag : uint32_t {
+    kColor = 0x00000001,
+    kDepth = 0x00000002,
+    kStencil = 0x00000004,
+    kDepthStencil = kDepth | kStencil,
+  };
+
+  // Defines a range of layers within the image.
+  struct LayerRange {
+    // Selects whether color, depth, and/or stencil aspects will be used.
+    AspectFlag aspect_mask = AspectFlag::kColor;
+    // Mipmap level source/target.
+    int mip_level = 0;
+    // Starting layer index.
+    int base_layer = 0;
+    // Total layer count.
+    int layer_count = 0;
+
+    LayerRange() = default;
+    LayerRange(AspectFlag aspect_mask, int mip_level, int base_layer,
+               int layer_count)
+        : aspect_mask(aspect_mask),
+          mip_level(mip_level),
+          base_layer(base_layer),
+          layer_count(layer_count) {}
+  };
+
+  struct CreateParams {
+    Type type = Image::Type::k2D;
+    PixelFormat format = PixelFormats::kUndefined;
+    SampleCount sample_count = SampleCount::k1;
+    TilingMode tiling_mode = TilingMode::kOptimal;
+    Size3D size;
+    int mip_level_count = 1;
+    int array_layer_count = 1;
+    Usage usage_mask = Usage::kNone;
+    Layout initial_layout = Layout::kUndefined;
+  };
+
+  ~Image() override = default;
+
+  // Image type the view is representing.
+  Image::Type type() const { return create_params_.type; }
+  // Format of the pixel data.
+  PixelFormat format() const { return create_params_.format; }
+  // The number of samples of the image, if it is to be multisampled.
+  SampleCount sample_count() const { return create_params_.sample_count; }
+  // Tiling mode of the image.
+  TilingMode tiling_mode() const { return create_params_.tiling_mode; }
+  // Size of the image in pixels of each valid dimension.
+  Size3D size() const { return create_params_.size; }
+  // Total number of levels of detail for mipmapping.
+  // A count of 1 indicates that no mipmapping is to be performed.
+  int mip_level_count() const { return create_params_.mip_level_count; }
+  // Total number of layers in the array, if the image is an array type.
+  int array_layer_count() const { return create_params_.array_layer_count; }
+  // Bitmask describing how the image is to be used.
+  Usage usage_mask() const { return create_params_.usage_mask; }
+
+  // Returns a layer range encompassing the entire image.
+  LayerRange entire_range() const {
+    return {create_params_.format.is_depth_stencil() ? AspectFlag::kDepthStencil
+                                                     : AspectFlag::kColor,
+            0, 0, create_params_.array_layer_count};
+  }
+
+ protected:
+  Image(size_t allocation_size, CreateParams create_params)
+      : Resource(allocation_size), create_params_(create_params) {}
+
+  CreateParams create_params_;
+};
+
+XRTL_BITMASK(Image::Usage);
+XRTL_BITMASK(Image::AspectFlag);
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_IMAGE_H_

--- a/xrtl/gfx/image_view.h
+++ b/xrtl/gfx/image_view.h
@@ -1,0 +1,63 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_IMAGE_VIEW_H_
+#define XRTL_GFX_IMAGE_VIEW_H_
+
+#include <utility>
+
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/image.h"
+#include "xrtl/gfx/pixel_format.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A view into an existing Image resource, possibly with a different type or
+// format and some subregion of the layers available.
+class ImageView : public RefObject<ImageView> {
+ public:
+  virtual ~ImageView() = default;
+
+  // Image this view is into.
+  ref_ptr<Image> image() const { return image_; }
+  // Image type the view is representing.
+  // This is compatible with the underlying Image.
+  Image::Type type() const { return type_; }
+  // Format of the pixel data.
+  // This is compatible with the underlying Image.
+  PixelFormat format() const { return format_; }
+  // Size of the image in pixels of each valid dimension.
+  Size3D size() const { return image_->size(); }
+  // Layer range within the target image.
+  Image::LayerRange layer_range() const { return layer_range_; }
+
+ protected:
+  ImageView(ref_ptr<Image> image, Image::Type type, PixelFormat format,
+            Image::LayerRange layer_range)
+      : image_(std::move(image)),
+        type_(type),
+        format_(format),
+        layer_range_(layer_range) {}
+
+  ref_ptr<Image> image_;
+  Image::Type type_ = Image::Type::k2D;
+  PixelFormat format_ = PixelFormats::kUndefined;
+  Image::LayerRange layer_range_;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_IMAGE_VIEW_H_

--- a/xrtl/gfx/memory_pool.h
+++ b/xrtl/gfx/memory_pool.h
@@ -1,0 +1,129 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_MEMORY_POOL_H_
+#define XRTL_GFX_MEMORY_POOL_H_
+
+#include "xrtl/base/macros.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/buffer.h"
+#include "xrtl/gfx/image.h"
+#include "xrtl/gfx/resource.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A bitmask specifying properties for a memory type.
+enum class MemoryType {
+  // Memory allocated with this type is the most efficient for device access.
+  kDeviceLocal = 1 << 0,
+
+  // Memory allocated with this type can be mapped for host access using
+  // Resource::MapMemory.
+  kHostVisible = 1 << 1,
+
+  // The host cache management commands Resource::FlushMappedMemory and
+  // Resource::InvalidateMappedMemory are not needed to flush host writes
+  // to the device or make device writes visible to the host, respectively.
+  kHostCoherent = 1 << 2,
+
+  // Memory allocated with this type is cached on the host. Host memory accesses
+  // to uncached memory are slower than to cached memory, however uncached
+  // memory is always host coherent.
+  kHostCached = 1 << 3,
+
+  // Memory is lazily allocated by the hardware and only exists transiently.
+  // This is the optimal mode for memory used only between subpasses in the same
+  // render pass, as it can often be kept entirely on-tile and discard when the
+  // render pass ends.
+  // The memory type only allows device access to the memory. Memory types must
+  // not have both this and kHostVisible set.
+  kLazilyAllocated = 1 << 4,
+};
+XRTL_BITMASK(MemoryType);
+
+// Memory pool for images and buffers.
+// Allocations that require reaching into the device to allocate memory are
+// expensive and there may be limits on the number of allocations that can be
+// performed by a process (sometimes on the order of low hundreds). MemoryPools
+// work around this by allocating large chunks of memory and then handing out
+// slices of that when requested as buffers or images.
+//
+// MemoryPools and the Resources allocated from them must be kept alive together
+// and the ref_ptr system should take care of this. This means that callers must
+// be careful not to allow Resources to hang around longer than required as it
+// may keep large chunks of memory reserved by a no-longer-used allocator.
+class MemoryPool : public RefObject<MemoryPool> {
+ public:
+  virtual ~MemoryPool() = default;
+
+  // TODO(benvanik): expose stats (total chunk size, chunks allocated, etc).
+  // TODO(benvanik): expose properties to query granularities for mapping/etc.
+
+  // A bitmask of MemoryType values describing the behavior of this memory.
+  MemoryType memory_type_mask() const { return memory_type_mask_; }
+  // Size of each chunk the allocator uses for backing memory in bytes.
+  size_t chunk_size() const { return chunk_size_; }
+
+  // Attempts to reclaim unused chunks from the system.
+  // Chunks will not be reclaimed so long as any resources allocated within it
+  // are still alive.
+  virtual void Reclaim() = 0;
+
+  // Defines the result of an allocation request.
+  enum class AllocationResult {
+    // Allocation was successful and the out param contains the new resource.
+    kSuccess,
+    // Invalid creation arguments, such as a nonsensical format or invalid size.
+    kInvalidArguments,
+    // The requested allocation makes sense is not supported by the current
+    // context.
+    kUnsupported,
+    // One or more device limits were exceeded by the specified parameters.
+    kLimitsExceeded,
+    // Device memory allocation would have been over the size of a single chunk.
+    // Grow the chunk size or use a different allocator.
+    kOverChunkSize,
+    // The memory pool servicing the memory type is exhausted.
+    kOutOfMemory,
+  };
+
+  // Allocates a buffer from the allocator memory pool.
+  // Returns the buffer via out_buffer if it could be allocated successfully.
+  // The allocation may fail if the buffer is larger than the allocator chunk
+  // size, memory is not available, or the buffer parameters are invalid or
+  // unsupported.
+  virtual AllocationResult AllocateBuffer(size_t size, Buffer::Usage usage_mask,
+                                          ref_ptr<Buffer>* out_buffer) = 0;
+
+  // Allocates an image from the allocator memory pool.
+  // Returns the image via out_image if it could be allocated successfully.
+  // The allocation may fail if the image is larger than the allocator chunk
+  // size, memory is not available, or the image parameters are invalid or
+  // unsupported.
+  virtual AllocationResult AllocateImage(Image::CreateParams create_params,
+                                         ref_ptr<Image>* out_image) = 0;
+
+ protected:
+  MemoryPool(MemoryType memory_type_mask, size_t chunk_size)
+      : memory_type_mask_(memory_type_mask), chunk_size_(chunk_size) {}
+
+  MemoryType memory_type_mask_;
+  size_t chunk_size_ = 0;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_MEMORY_POOL_H_

--- a/xrtl/gfx/pipeline.h
+++ b/xrtl/gfx/pipeline.h
@@ -1,0 +1,121 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_PIPELINE_H_
+#define XRTL_GFX_PIPELINE_H_
+
+#include <string>
+#include <utility>
+
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/pipeline_layout.h"
+#include "xrtl/gfx/render_state.h"
+#include "xrtl/gfx/shader_module.h"
+
+namespace xrtl {
+namespace gfx {
+
+// Base shader pipeline.
+class Pipeline : public RefObject<Pipeline> {
+ public:
+  virtual ~Pipeline() = default;
+
+  // Layout of the pipeline denoting what other pipelines it is compatible with.
+  ref_ptr<PipelineLayout> pipeline_layout() const { return pipeline_layout_; }
+
+ protected:
+  explicit Pipeline(ref_ptr<PipelineLayout> pipeline_layout)
+      : pipeline_layout_(pipeline_layout) {}
+
+  ref_ptr<PipelineLayout> pipeline_layout_;
+};
+
+// A pipeline used for compute operations.
+class ComputePipeline : public Pipeline {
+ public:
+  ~ComputePipeline() override = default;
+
+  // Source shader module.
+  ref_ptr<ShaderModule> shader_module() const { return shader_module_; }
+  // Entry point name within the shader module.
+  const std::string& entry_point() const { return entry_point_; }
+
+ protected:
+  ComputePipeline(ref_ptr<PipelineLayout> pipeline_layout,
+                  ref_ptr<ShaderModule> shader_module, std::string entry_point)
+      : Pipeline(std::move(pipeline_layout)),
+        shader_module_(std::move(shader_module)),
+        entry_point_(std::move(entry_point)) {}
+
+  ref_ptr<ShaderModule> shader_module_;
+  std::string entry_point_;
+};
+
+// A pipeline used for rendering.
+// Each render pipeline is specific to a (render pass, subpass) pair and fully
+// describes all static render state to be used while the pipeline is active.
+// Some state is dynamically specified on the RenderPassCommandEncoder.
+class RenderPipeline : public Pipeline {
+ public:
+  // All shader stage modules and entry points.
+  // If any are omitted the shader stage will not be enabled for the pipeline.
+  // Multiple stages may refrence the same shader module so long as they have
+  // differing and stage-compatible entry points.
+  struct ShaderStages {
+    ref_ptr<ShaderModule> vertex_shader_module;
+    std::string vertex_entry_point;
+    ref_ptr<ShaderModule> tessellation_control_shader_module;
+    std::string tessellation_control_entry_point;
+    ref_ptr<ShaderModule> tessellation_evaluation_shader_module;
+    std::string tessellation_evaluation_entry_point;
+    ref_ptr<ShaderModule> geometry_shader_module;
+    std::string geometry_entry_point;
+    ref_ptr<ShaderModule> fragment_shader_module;
+    std::string fragment_entry_point;
+  };
+
+  ~RenderPipeline() override = default;
+
+  // Render pass the pipeline is used in.
+  ref_ptr<RenderPass> render_pass() const { return render_pass_; }
+  // Subpass index within the render pass the pipeline is used in.
+  int render_subpass() const { return render_subpass_; }
+
+  // All render state for the pipeline.
+  const RenderState& render_state() const { return render_state_; }
+
+  // All shader stages for the pipeline, possibly only partially populated.
+  const ShaderStages& shader_stages() const { return shader_stages_; }
+
+ protected:
+  RenderPipeline(ref_ptr<PipelineLayout> pipeline_layout,
+                 ref_ptr<RenderPass> render_pass, int render_subpass,
+                 RenderState render_state,
+                 RenderPipeline::ShaderStages shader_stages)
+      : Pipeline(std::move(pipeline_layout)),
+        render_pass_(std::move(render_pass)),
+        render_subpass_(render_subpass),
+        render_state_(std::move(render_state)),
+        shader_stages_(std::move(shader_stages)) {}
+
+  ref_ptr<RenderPass> render_pass_;
+  int render_subpass_ = 0;
+  RenderState render_state_;
+  ShaderStages shader_stages_;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_PIPELINE_H_

--- a/xrtl/gfx/pipeline_layout.h
+++ b/xrtl/gfx/pipeline_layout.h
@@ -1,0 +1,93 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_PIPELINE_LAYOUT_H_
+#define XRTL_GFX_PIPELINE_LAYOUT_H_
+
+#include <vector>
+
+#include "xrtl/base/array_view.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/render_pass.h"
+
+namespace xrtl {
+namespace gfx {
+
+enum class BindingType {
+  kSampler = 0,
+  kCombinedImageSampler = 1,
+  kSampledImage = 2,
+  kStorageImage = 3,
+  kUniformTexelBuffer = 4,
+  kStorageTexelBuffer = 5,
+  kUniformBuffer = 6,
+  kStorageBuffer = 7,
+  kUniformBufferDynamic = 8,
+  kStorageBufferDynamic = 9,
+  kInputAttachment = 10,
+};
+
+struct PipelineBinding {
+  // Binding number of this entry and corresponds to a resource of the same
+  // binding number in the shader stages.
+  int binding = 0;
+  // Specifies which type of resources are used for this binding.
+  BindingType type = BindingType::kSampler;
+  // The number of slots contained in the binding, accessed in a shader as
+  // an array.
+  int array_count = 0;
+  // A bitmask specifying which pipeline shader stages can access a resource for
+  // this binding.
+  ShaderStageFlag stage_mask = ShaderStageFlag::kAll;
+};
+
+// Describes a range of push constant data within the pipeline.
+struct PushConstantRange {
+  // A set of stage flags describing the shader stages that will access a range
+  // of push constants.
+  ShaderStageFlag stage_mask = ShaderStageFlag::kNone;
+
+  // Start offset and size, respectively, consumed by the range.
+  // Both offset and size are in units of bytes and must be a multiple of 4.
+  size_t offset = 0;
+  size_t size = 0;
+};
+
+// Completely describes the layout of pipeline bindings.
+// This is used to allow multiple pipelines to share the same descriptor sets.
+//
+// In Vulkan this encompasses both a PipelineLayout and set of
+// DescriptorSetLayouts.
+class PipelineLayout : public RefObject<PipelineLayout> {
+ public:
+  virtual ~PipelineLayout() = default;
+
+  const std::vector<PipelineBinding>& bindings() const { return bindings_; }
+  const std::vector<PushConstantRange>& push_constant_ranges() const {
+    return push_constant_ranges_;
+  }
+
+ protected:
+  PipelineLayout(ArrayView<PipelineBinding> bindings,
+                 ArrayView<PushConstantRange> push_constant_ranges)
+      : bindings_(bindings), push_constant_ranges_(push_constant_ranges) {}
+
+  std::vector<PipelineBinding> bindings_;
+  std::vector<PushConstantRange> push_constant_ranges_;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_PIPELINE_LAYOUT_H_

--- a/xrtl/gfx/pixel_format.h
+++ b/xrtl/gfx/pixel_format.h
@@ -169,6 +169,7 @@ enum class ComponentFormat : uint8_t {
 // us to use tables to map to internal formats.
 class PixelFormat {
  public:
+  PixelFormat() = default;
   constexpr PixelFormat(uint8_t unique_id, PixelPacking packing_format,
                         uint8_t packed_bytes_per_pixel,
                         ComponentFormat component_format,
@@ -230,10 +231,15 @@ class PixelFormat {
             static_cast<uint8_t>(PixelPacking::kFlexibleMask)) != 0;
   }
 
-  // Returns true if the given color format contains compressed data.
+  // Returns true if the given format contains compressed data.
   constexpr bool is_compressed() const {
     return (static_cast<uint8_t>(packing_format_) &
             static_cast<uint8_t>(PixelPacking::kCompressedMask)) != 0;
+  }
+
+  // Returns true if the given format represents depth/stencil data.
+  constexpr bool is_depth_stencil() const {
+    return packing_format_ == PixelPacking::kDepthStencil;
   }
 
   // Returns true if the given color format includes an alpha channel or other

--- a/xrtl/gfx/pixel_format_test.cc
+++ b/xrtl/gfx/pixel_format_test.cc
@@ -77,6 +77,7 @@ TEST(PixelFormatTest, UncompressedTypes) {
   EXPECT_EQ(2, format.component_bits_a());
   EXPECT_FALSE(format.is_flexible());
   EXPECT_FALSE(format.is_compressed());
+  EXPECT_FALSE(format.is_depth_stencil());
   EXPECT_TRUE(format.has_transparency());
   EXPECT_TRUE(format.is_linear());
   EXPECT_EQ(4 * 100 * 100, format.ComputeDataSize(100, 100));
@@ -93,6 +94,7 @@ TEST(PixelFormatTest, DepthStencilTypes) {
   EXPECT_EQ(8, format.component_bits_stencil());
   EXPECT_FALSE(format.is_flexible());
   EXPECT_FALSE(format.is_compressed());
+  EXPECT_TRUE(format.is_depth_stencil());
   EXPECT_FALSE(format.has_transparency());
   EXPECT_TRUE(format.is_linear());
   EXPECT_EQ(4 * 100 * 100, format.ComputeDataSize(100, 100));
@@ -111,6 +113,7 @@ TEST(PixelFormatTest, CompressedTypes) {
   EXPECT_EQ(1, format.component_bits_a());
   EXPECT_FALSE(format.is_flexible());
   EXPECT_TRUE(format.is_compressed());
+  EXPECT_FALSE(format.is_depth_stencil());
   EXPECT_TRUE(format.has_transparency());
   EXPECT_FALSE(format.is_linear());
   EXPECT_EQ(100 * 100, format.ComputeDataSize(100, 100));

--- a/xrtl/gfx/queue_fence.h
+++ b/xrtl/gfx/queue_fence.h
@@ -1,0 +1,41 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_QUEUE_FENCE_H_
+#define XRTL_GFX_QUEUE_FENCE_H_
+
+#include "xrtl/base/ref_ptr.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A fence that orders queue command buffer submissions.
+// These may be signaled once per object. Attempting to signal an already-
+// signaled fence may produce undefined results.
+//
+// These are device-side only and are only used to order the way command
+// buffers are processed. They cannot be used for synchronization with the
+// CPU.
+class QueueFence : public RefObject<QueueFence> {
+ public:
+  virtual ~QueueFence() = default;
+
+ protected:
+  QueueFence() = default;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_QUEUE_FENCE_H_

--- a/xrtl/gfx/render_pass.h
+++ b/xrtl/gfx/render_pass.h
@@ -1,0 +1,384 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_RENDER_PASS_H_
+#define XRTL_GFX_RENDER_PASS_H_
+
+#include <vector>
+
+#include "xrtl/base/array_view.h"
+#include "xrtl/base/macros.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/image.h"
+#include "xrtl/gfx/pixel_format.h"
+#include "xrtl/gfx/render_state.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A bitmask specifying pipeline stage flags.
+enum class PipelineStageFlag : uint32_t {
+  // Stage of the pipeline where commands are initially received by the queue.
+  // Queue: any.
+  kTopOfPipe = 1 << 0,
+  // Stage of the pipeline where Draw/DispatchIndirect data structures are
+  // consumed.
+  // Queue: kRender or kCompute.
+  kDrawIndirect = 1 << 1,
+  // Stage of the pipeline where vertex and index buffers are consumed.
+  // Queue: kRender.
+  kVertexInput = 1 << 2,
+  // Vertex shader stage.
+  // Queue: kRender.
+  kVertexShader = 1 << 3,
+  // Tessellation control shader stage.
+  // Queue: kRender.
+  kTessellationControlShader = 1 << 4,
+  // Tessellation evaluation shader stage.
+  // Queue: kRender.
+  kTessellationEvaluationShader = 1 << 5,
+  // Geometry shader stage.
+  // Queue: kRender.
+  kGeometryShader = 1 << 6,
+  // Fragment shader stage.
+  // Queue: kRender.
+  kFragmentShader = 1 << 7,
+  // Stage of the pipeline where early fragment tests (depth and stencil tests
+  // before fragment shading) are performed.
+  // Queue: kRender.
+  kEarlyFragmentTests = 1 << 8,
+  // Stage of the pipeline where late fragment tests (depth and stencil tests
+  // after fragment shading) are performed.
+  // Queue: kRender.
+  kLateFragmentTests = 1 << 9,
+  // Stage of the pipeline after blending where the final color values are
+  // output from the pipeline. This stage also includes resolve operations that
+  // occur at the end of a subpass. Note that this does not necessarily indicate
+  // that the values have been committed to memory.
+  // Queue: kRender.
+  kColorAttachmentOutput = 1 << 10,
+  // Execution of a compute shader.
+  // Queue: kCompute.
+  kComputeShader = 1 << 11,
+  // Execution of copy commands. This includes the operations resulting from all
+  // transfer commands. The set of transfer commands comprises:
+  //   CopyBuffer
+  //   CopyImage
+  //   BlitImage
+  //   CopyBufferToImage
+  //   CopyImageToBuffer
+  //   UpdateBuffer
+  //   FillBuffer
+  //   ClearColorImage
+  //   ClearDepthStencilImage
+  //   ResolveImage
+  //   CopyQueryPoolResults
+  // Queue: any.
+  kTransfer = 1 << 12,
+  // Final stage in the pipeline where commands complete execution.
+  // Queue: any.
+  kBottomOfPipe = 1 << 13,
+  // A pseudo-stage indicating execution on the host of reads/writes of device
+  // memory.
+  // Queue: any.
+  kHost = 1 << 14,
+  // Execution of all graphics pipeline stages.
+  // Queue: kRender.
+  kAllGraphics = 1 << 15,
+  // Execution of all stages supported on the queue.
+  // Queue: any.
+  kAllCommands = 1 << 16,
+};
+XRTL_BITMASK(PipelineStageFlag);
+
+// A bitmask specifying a pipeline stage.
+enum class ShaderStageFlag : uint32_t {
+  kNone = 0,
+  kVertex = 1 << 0,
+  kTessellationControl = 1 << 1,
+  kTessellationEvaluation = 1 << 2,
+  kGeometry = 1 << 3,
+  kFragment = 1 << 4,
+  kCompute = 1 << 5,
+  kAllGraphics = 1 << 6,
+  kAll = 1 << 7,
+};
+XRTL_BITMASK(ShaderStageFlag);
+
+// A bitmask specifying pipeline dependencies.
+enum class PipelineDependencyFlag : uint32_t {
+  // Dependencies will be framebuffer-local (as opposed to framebuffer-global).
+  // Framebuffer local dependencies are significantly more performant on tiled
+  // renderers as global barriers require a full flush back to main memory.
+  kFramebufferLocal = 1 << 0,
+};
+XRTL_BITMASK(PipelineDependencyFlag);
+
+// A bitmask specifying the pipeline access flags.
+enum class AccessFlag : uint32_t {
+  // Indicates that the access is an indirect command structure read as part of
+  // an indirect drawing command.
+  // Queue: kRender or kCompute.
+  kIndirectCommandRead = 1 << 0,
+  // Indicates that the access is an index buffer read.
+  // Queue: kRender.
+  kIndexRead = 1 << 1,
+  // Indicates that the access is a read via the vertex input bindings.
+  // Queue: kRender.
+  kVertexAttributeRead = 1 << 2,
+  // Indicates that the access is a read via a uniform buffer or dynamic uniform
+  // buffer descriptor.
+  // Queue: kRender or kCompute.
+  kUniformRead = 1 << 3,
+  // Indicates that the access is a read via an input attachment descriptor.
+  // Queue: kRender.
+  kInputAttachmentRead = 1 << 4,
+  // Indicates that the access is a read from a shader via any other descriptor
+  // type.
+  // Queue: kRender or kCompute.
+  kShaderRead = 1 << 5,
+  // Indicates that the access is a write or atomic from a shader via the same
+  // descriptor types as in kShaderRead.
+  // Queue: kRender or kCompute.
+  kShaderWrite = 1 << 6,
+  // Indicates that the access is a read via a color attachment.
+  // Queue: kRender.
+  kColorAttachmentRead = 1 << 7,
+  // Indicates that the access is a write via a color or resolve attachment.
+  // Queue: kRender.
+  kColorAttachmentWrite = 1 << 8,
+  // Indicates that the access is a read via a depth/stencil attachment.
+  // Queue: kRender.
+  kDepthStencilAttachmentRead = 1 << 9,
+  // Indicates that the access is a write via a depth/stencil attachment.
+  // Queue: kRender.
+  kDepthStencilAttachmentWrite = 1 << 10,
+  // Indicates that the access is a read from a transfer (copy, blit, resolve,
+  // etc) operation.
+  // Queue: any.
+  kTransferRead = 1 << 11,
+  // Indicates that the access is a write from a transfer (copy, blit, resolve,
+  // etc) operation.
+  // Queue: any.
+  kTransferWrite = 1 << 12,
+  // Indicates that the access is a read via the host.
+  // Queue: any.
+  kHostRead = 1 << 13,
+  // Indicates that the access is a write via the host.
+  // Queue: any.
+  kHostWrite = 1 << 14,
+  // Indicates that the access is a read via a non-specific unit attached to the
+  // memory
+  // Queue: any.
+  kMemoryRead = 1 << 15,
+  // Indicates that the access is a write via a non-specific unit attached to
+  // the memory
+  // Queue: any.
+  kMemoryWrite = 1 << 16,
+};
+XRTL_BITMASK(AccessFlag);
+
+class RenderPass : public RefObject<RenderPass> {
+ public:
+  // A sentinel that can be used in place of subpass indices to denote an
+  // external data source. This may be used as a source to denote input
+  // framebuffer data or a target to denote exported framebuffer data.
+  static constexpr int kExternalSubpass = -1;
+
+  // Defines how values are handled for attachments when loading.
+  enum class LoadOp {
+    // The previous contents of the image within the render area will be loaded
+    // from memory and preserved.
+    //
+    // Uses either AccessFlag::kColorAttachmentRead or
+    // kDepthStencilAttachmentRead.
+    kLoad = 0,
+
+    // The contents within the render area will be cleared to a uniform value
+    // which is specified when a render pass instance is begun.
+    //
+    // Uses either AccessFlag::kColorAttachmentWrite or
+    // kDepthStencilAttachmentWrite.
+    kClear = 1,
+
+    // The previous contents within the area need not be preserved; the contents
+    // of the attachment will be undefined inside the render area.
+    //
+    // Uses either AccessFlag::kColorAttachmentWrite or
+    // kDepthStencilAttachmentWrite.
+    kDontCare = 2,
+  };
+
+  // Defines how values are handled for attachments when storing.
+  enum class StoreOp {
+    // The contents generated during the render pass and within the render area
+    // are written to memory.
+    //
+    // Uses either AccessFlag::kColorAttachmentWrite or
+    // kDepthStencilAttachmentWrite.
+    kStore = 0,
+
+    // The contents within the render area are not needed after rendering and
+    // may be discarded; the contents of the attachment will be undefined inside
+    // the render area.
+    //
+    // Uses either AccessFlag::kColorAttachmentWrite or
+    // kDepthStencilAttachmentWrite.
+    kDontCare = 1,
+  };
+
+  // Specifies an attachment for a render pass.
+  //
+  // Reference:
+  // https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkAttachmentDescription.html
+  struct AttachmentDescription {
+    // Specifyies the format of the image that will be used for the
+    // attachment.
+    PixelFormat format = PixelFormats::kUndefined;
+    // The number of samples of the image, if it is to be multisampled.
+    SampleCount sample_count = SampleCount::k1;
+    // Specifies how the contents of color and depth components of the
+    // attachment are treated at the beginning of the subpass where it is first
+    // used.
+    LoadOp load_op = LoadOp::kDontCare;
+    // Specifies how the contents of color and depth components of the
+    // attachment are treated at the end of the subpass where it is last used.
+    StoreOp store_op = StoreOp::kDontCare;
+    // Specifies how the contents of stencil components of the attachment are
+    // treated at the beginning of the subpass where it is first used.
+    LoadOp stencil_load_op = LoadOp::kDontCare;
+    // Specifies how the contents of stencil components of the attachment are
+    // treated at the end of the last subpass where it is used.
+    StoreOp stencil_store_op = StoreOp::kDontCare;
+    // The layout the attachment image subresource will be in when a render pass
+    // instance begins.
+    Image::Layout initial_layout = Image::Layout::kUndefined;
+    // The layout the attachment image subresource will be transitioned to when
+    // a render pass instance ends. During a render pass instance an attachment
+    // can use a different layout in each subpass, if desired.
+    Image::Layout final_layout = Image::Layout::kGeneral;
+  };
+
+  // A reference to one of the attachments provided to the render pass.
+  struct AttachmentReference {
+    // Denotes that an attachment is not used and will not be written.
+    static constexpr int kUnused = -1;
+    // The index of the attachment of the render pass corresponding to the index
+    // of the attachment in the render pass attachments array. If kUnused the
+    // attachment is not used in the subpass and no writes will occur.
+    int index = kUnused;
+    // The layout the attachment uses during the subpass.
+    Image::Layout layout = Image::Layout::kGeneral;
+
+    AttachmentReference() = default;
+    AttachmentReference(int index, Image::Layout layout)
+        : index(index), layout(layout) {}
+  };
+
+  // Specifies a subpass description.
+  //
+  // Reference:
+  // https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkSubpassDescription.html
+  struct SubpassDescription {
+    // An array listing which of the render pass's attachments can be read in
+    // shaders during the subpass and what layout each attachment will be in
+    // during the subpass.
+    //
+    // Each element of the array corresponds to an input attachment unit number
+    // in the shader, i.e. if the shader declares an input variable
+    // `layout(input_attachment_index=X, set=Y, binding=Z)` then it uses the
+    // attachment provided in input_attachments[X]. Input attachments must also
+    // be bound to the pipeline with a descriptor set with the input attachment
+    // descriptor written in the location (set=Y, binding=Z).
+    std::vector<AttachmentReference> input_attachments;
+
+    // An array listing which of the render pass’s attachments will be used as
+    // color attachments in the subpass and what layout each attachment will be
+    // in during the subpass. Each element of the array corresponds to a
+    // fragment shader output location, i.e. if the shader declared an output
+    // variable `layout(location=X)` then it uses the attachment provided in
+    // color_attachments[X].
+    std::vector<AttachmentReference> color_attachments;
+
+    // An array listing which of the render pass’s attachments are resolved to
+    // at the end of the subpass and what layout each attachment will be in
+    // during the multisample resolve operation. If this is not empty it must be
+    // the same size as color_attachments and the indices between the two
+    // correspond.
+    std::vector<AttachmentReference> resolve_attachments;
+
+    // Specifies which attachment will be used for depth/stencil data and the
+    // layout it will be in during the subpass. Setting the attachment index to
+    // kUnused indicates that no depth/stencil attachment will be used in the
+    // subpass.
+    AttachmentReference depth_stencil_attachment;
+
+    // An array listing which of the render pass's attachments are not used by a
+    // subpass but whose contents must be preserved throughout the subpass.
+    std::vector<AttachmentReference> preserve_attachments;
+  };
+
+  // Specifies a subpass dependency.
+  //
+  // Reference:
+  // https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkSubpassDependency.html
+  struct SubpassDependency {
+    // Index of the source subpass in the dependency or kExternalSubpass.
+    int source_subpass = kExternalSubpass;
+    // Index of the target subpass in the dependency or kExternalSubpass.
+    int target_subpass = kExternalSubpass;
+    PipelineStageFlag source_stage_mask;
+    PipelineStageFlag target_stage_mask;
+    AccessFlag source_access_mask;
+    AccessFlag target_access_mask;
+    PipelineDependencyFlag dependency_flags;
+  };
+
+  virtual ~RenderPass() = default;
+
+  // A list of attachment descriptions.
+  // Framebuffers must contain attachments corresponding to the indices of the
+  // attachments described here. Each attachment must be format-compatible.
+  const std::vector<AttachmentDescription>& attachments() const {
+    return attachments_;
+  }
+
+  // A list of subpasses within the render pass.
+  // All render passes need at least one subpass.
+  const std::vector<SubpassDescription>& subpasses() const {
+    return subpasses_;
+  }
+
+  // Declarations of dependencies between the subpasses within this render pass.
+  const std::vector<SubpassDependency>& subpass_dependencies() const {
+    return subpass_dependencies_;
+  }
+
+ protected:
+  RenderPass(ArrayView<AttachmentDescription> attachments,
+             ArrayView<SubpassDescription> subpasses,
+             ArrayView<SubpassDependency> subpass_dependencies)
+      : attachments_(attachments),
+        subpasses_(subpasses),
+        subpass_dependencies_(subpass_dependencies) {}
+
+  std::vector<AttachmentDescription> attachments_;
+  std::vector<SubpassDescription> subpasses_;
+  std::vector<SubpassDependency> subpass_dependencies_;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_RENDER_PASS_H_

--- a/xrtl/gfx/render_state.h
+++ b/xrtl/gfx/render_state.h
@@ -1,0 +1,633 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_RENDER_STATE_H_
+#define XRTL_GFX_RENDER_STATE_H_
+
+#include <cstdint>
+
+#include "xrtl/base/fixed_vector.h"
+#include "xrtl/gfx/pixel_format.h"
+
+namespace xrtl {
+namespace gfx {
+
+// Maximum number of vertex bindings and attributes.
+// There may be a larger number supported by the device but this is all the
+// space we reserve for now.
+constexpr int kMaxVertexInputs = 16;
+
+// Maximum number of color attachments.
+// There may be a larger number supported by the device but this is all the
+// space we reserve for now.
+constexpr int kMaxColorAttachments = 8;
+
+enum class PrimitiveTopology {
+  kPointList = 0,
+  kLineList = 1,
+  kLineStrip = 2,
+  kTriangleList = 3,
+  kTriangleStrip = 4,
+  kTriangleFan = 5,
+  kLineListWithAdjacency = 6,
+  kLineStripWithAdjacency = 7,
+  kTriangleListWithAdjacency = 8,
+  kTriangleStripWithAdjacency = 9,
+  kPatchList = 10,
+};
+constexpr int kPrimitiveTopologyBits = 4;
+
+enum class PolygonMode {
+  kFill = 0,
+  kLine = 1,
+  kPoint = 2,
+};
+constexpr int kPolygonModeBits = 2;
+
+enum class CullMode {
+  kNone = 0,
+  kFront = 1,
+  kBack = 2,
+  kFrontAndBack = 3,
+};
+constexpr int kCullModeBits = 3;
+
+enum class FrontFace {
+  kCounterClockwise = 0,
+  kClockwise = 1,
+};
+constexpr int kFrontFaceBits = 1;
+
+// Sample count used for multisampling.
+enum class SampleCount : uint32_t {
+  k1 = 1,
+  k2 = 2,
+  k4 = 4,
+  k8 = 8,
+  k16 = 16,
+  k32 = 32,
+  k64 = 64,
+};
+XRTL_BITMASK(SampleCount);
+constexpr int kSampleCountBits = 7;
+
+// Reference:
+// https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkBlendFactor.html
+enum class BlendFactor {
+  // Color: (0,0,0)
+  // Alpha: 0
+  kZero = 0,
+  // Color: (1,1,1)
+  // Alpha: 1
+  kOne = 1,
+  // Color: (Rs0,Gs0,Bs0)
+  // Alpha: As0
+  kSrcColor = 2,
+  // Color: (1-Rs0,1-Gs0,1-Bs0)
+  // Alpha: 1-As0
+  kOneMinusSrcColor = 3,
+  // Color: (Rd,Gd,Bd)
+  // Alpha: Ad
+  kDstColor = 4,
+  // Color: (1-Rd,1-Gd,1-Bd)
+  // Alpha: 1-Ad
+  kOneMinusDstColor = 5,
+  // Color: (As0,As0,As0)
+  // Alpha: As0
+  kSrcAlpha = 6,
+  // Color: (1-As0,1-As0,1-As0)
+  // Alpha: 1-As0
+  kOneMinusSrcAlpha = 7,
+  // Color: (Ad,Ad,Ad)
+  // Alpha: Ad
+  kDstAlpha = 8,
+  // Color: (1-Ad,1-Ad,1-Ad)
+  // Alpha: 1-Ad
+  kOneMinusDstAlpha = 9,
+  // Color: (Rc,Gc,Bc)
+  // Alpha: Ac
+  kConstantColor = 10,
+  // Color: (1-Rc,1-Gc,1-Bc)
+  // Alpha: 1-Ac
+  kOneMinusConstantColor = 11,
+  // Color: (Ac,Ac,Ac)
+  // Alpha: Ac
+  kConstantAlpha = 12,
+  // Color: (1-Ac,1-Ac,1-Ac)
+  // Alpha: 1-Ac
+  kOneMinusConstantAlpha = 13,
+  // Color: (f,f,f); f = min(As0,1-Ad)
+  // Alpha: 1
+  kSrcAlphaSaturate = 14,
+  // Color: (Rs1,Gs1,Bs1)
+  // Alpha: As1
+  kSrc1Color = 15,
+  // Color: (1-Rs1,1-Gs1,1-Bs1)
+  // Alpha: 1-As1
+  kOneMinusSrc1Color = 16,
+  // Color: (As1,As1,As1)
+  // Alpha: As1
+  kSrc1Alpha = 17,
+  // Color: (1-As1,1-As1,1-As1)
+  // Alpha: 1-As1
+  kOneMinusSrc1Alpha = 18,
+};
+constexpr int kBlendFactorBits = 5;
+
+// Reference:
+// https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkBlendOp.html
+enum class BlendOp {
+  // R = Rs0 × Sr + Rd × Dr
+  // G = Gs0 × Sg + Gd × Dg
+  // B = Bs0 × Sb + Bd × Db
+  // A = As0 × Sa + Ad × Da
+  kAdd = 0,
+
+  // R = Rs0 × Sr - Rd × Dr
+  // G = Gs0 × Sg - Gd × Dg
+  // B = Bs0 × Sb - Bd × Db
+  // A = As0 × Sa - Ad × Da
+  kSubtract = 1,
+
+  // R = Rd × Dr - Rs0 × Sr
+  // G = Gd × Dg - Gs0 × Sg
+  // B = Bd × Db - Bs0 × Sb
+  // A = Ad × Da - As0 × Sa
+  kReverseSubtract = 2,
+
+  // R = min(Rs0,Rd)
+  // G = min(Gs0,Gd)
+  // B = min(Bs0,Bd)
+  // A = min(As0,Ad)
+  kMin = 3,
+
+  // R = max(Rs0,Rd)
+  // G = max(Gs0,Gd)
+  // B = max(Bs0,Bd)
+  // A = max(As0,Ad)
+  kMax = 4,
+};
+constexpr int kBlendOpBits = 3;
+
+enum class ColorComponentMask : uint32_t {
+  kR = 0x1,
+  kG = 0x2,
+  kB = 0x4,
+  kA = 0x8,
+  kRGB = kR | kG | kB,
+  kRGBA = kR | kG | kB | kA,
+};
+XRTL_BITMASK(ColorComponentMask);
+constexpr int kColorComponentMaskBits = 4;
+
+enum class VertexInputRate {
+  // Indicates that vertex attribute addressing is a function of the vertex
+  // index.
+  kVertex = 0,
+  // Indicates that vertex attribute addressing is a function of the instance
+  // index.
+  kInstance = 1,
+};
+
+struct VertexInputBinding {
+  // The binding number that this structure describes.
+  int binding = 0;
+  // Distance in bytes between two consecutive elements within the buffer.
+  size_t stride = 0;
+  // Specifies whether vertex attribute addressing is a function of the vertex
+  // index or of the instance index.
+  VertexInputRate input_rate = VertexInputRate::kVertex;
+
+  VertexInputBinding() = default;
+  VertexInputBinding(int binding, size_t stride)
+      : binding(binding), stride(stride) {}
+  VertexInputBinding(int binding, size_t stride, VertexInputRate input_rate)
+      : binding(binding), stride(stride), input_rate(input_rate) {}
+};
+
+struct VertexInputAttribute {
+  // The shader binding location number for this attribute.
+  int location = 0;
+  // The binding number which this attribute takes its data from.
+  int binding = 0;
+  // A byte offset of this attribute relative to the start of an element in the
+  // vertex input binding.
+  size_t offset = 0;
+  // The size and type of the vertex attribute data.
+  PixelFormat format = PixelFormats::kUndefined;
+
+  VertexInputAttribute() = default;
+  VertexInputAttribute(int location, int binding, size_t offset,
+                       PixelFormat format)
+      : location(location), binding(binding), offset(offset), format(format) {}
+};
+
+class RenderState {
+ public:
+  class VertexInputState {
+   public:
+    VertexInputState() = default;
+
+    FixedVector<VertexInputBinding, kMaxVertexInputs> vertex_bindings;
+    FixedVector<VertexInputAttribute, kMaxVertexInputs> vertex_attributes;
+  };
+  VertexInputState vertex_input_state;
+
+  class InputAssemblyState {
+   public:
+    InputAssemblyState() {
+      primitive_topology_ = PrimitiveTopology::kTriangleList;
+      primitive_restart_enabled_ = false;
+    }
+
+    // Defines the primitive topology.
+    PrimitiveTopology primitive_topology() const { return primitive_topology_; }
+    void set_primitive_topology(PrimitiveTopology value) {
+      primitive_topology_ = value;
+    }
+
+    // Whether a special vertex index value is treated as restarting the
+    // assembly of primitives when performing an indexed draw. For 16-bit
+    // index buffers the value is 0xFFFF and for 32-bit index buffers the value
+    // is 0xFFFFFFFF.
+    bool is_primitive_restart_enabled() const {
+      return primitive_restart_enabled_;
+    }
+    void set_primitive_restart_enabled(bool value) {
+      primitive_restart_enabled_ = value;
+    }
+
+   private:
+    PrimitiveTopology primitive_topology_ : kPrimitiveTopologyBits;
+    bool primitive_restart_enabled_ : 1;
+  };
+  InputAssemblyState input_assembly_state;
+
+  class TessellationState {
+   public:
+    TessellationState() { patch_control_points_ = 1; }
+
+    // Number of control points per patch.
+    int patch_control_points() const { return patch_control_points_; }
+    void set_patch_control_points(int value) { patch_control_points_ = value; }
+
+   private:
+    int patch_control_points_;
+  };
+  TessellationState tessellation_state;
+
+  class ViewportState {
+   public:
+    ViewportState() { count_ = 1; }
+
+    // Total number of viewports enabled during this pipeline.
+    int count() const { return count_; }
+    void set_count(int value) { count_ = value; }
+
+   private:
+    int count_;
+  };
+  ViewportState viewport_state;
+
+  class RasterizationState {
+   public:
+    RasterizationState() {
+      depth_clamp_enabled_ = false;
+      rasterizer_discard_enabled_ = false;
+      polygon_mode_ = PolygonMode::kFill;
+      cull_mode_ = CullMode::kNone;
+      front_face_ = FrontFace::kCounterClockwise;
+      depth_bias_enabled_ = false;
+    }
+
+    // Controls whether to clamp the fragment’s depth values instead of clipping
+    // primitives to the z planes of the frustum.
+    bool is_depth_clamp_enabled() const { return depth_clamp_enabled_; }
+    void set_depth_clamp_enabled(bool value) { depth_clamp_enabled_ = value; }
+
+    // Controls whether primitives are discarded immediately before the
+    // rasterization stage.
+    bool is_rasterizer_discard_enabled() const {
+      return rasterizer_discard_enabled_;
+    }
+    void set_rasterizer_discard_enabled(bool value) {
+      rasterizer_discard_enabled_ = value;
+    }
+
+    // Polygon rendering mode.
+    PolygonMode polygon_mode() const { return polygon_mode_; }
+    void set_polygon_mode(PolygonMode value) { polygon_mode_ = value; }
+
+    // The triangle facing direction used for primitive culling.
+    CullMode cull_mode() const { return cull_mode_; }
+    void set_cull_mode(CullMode value) { cull_mode_ = value; }
+
+    // The front-facing triangle orientation to be used for culling.
+    FrontFace front_face() const { return front_face_; }
+    void set_front_face(FrontFace value) { front_face_ = value; }
+
+    // Controls whether to bias fragment depth values.
+    bool is_depth_bias_enabled() const { return depth_bias_enabled_; }
+    void set_depth_bias_enabled(bool value) { depth_bias_enabled_ = value; }
+
+   private:
+    bool depth_clamp_enabled_ : 1;
+    bool rasterizer_discard_enabled_ : 1;
+    PolygonMode polygon_mode_ : kPolygonModeBits;
+    CullMode cull_mode_ : kCullModeBits;
+    FrontFace front_face_ : kFrontFaceBits;
+    bool depth_bias_enabled_ : 1;
+  };
+  RasterizationState rasterization_state;
+
+  class MultisampleState {
+   public:
+    MultisampleState() {
+      rasterization_samples_ = SampleCount::k1;
+      alpha_to_coverage_enabled_ = false;
+      alpha_to_one_enabled_ = false;
+      sample_shading_enabled_ = false;
+      min_sample_shading_ = 0.0f;
+    }
+
+    // Specifies the number of samples per pixel used in rasterization.
+    SampleCount rasterization_samples() const { return rasterization_samples_; }
+    void set_rasterization_samples(SampleCount value) {
+      rasterization_samples_ = value;
+    }
+
+    // Controls whether a temporary coverage value is generated based on the
+    // alpha component of the fragment’s first color output.
+    bool is_alpha_to_coverage_enabled() const {
+      return alpha_to_coverage_enabled_;
+    }
+    void set_alpha_to_coverage_enabled(bool value) {
+      alpha_to_coverage_enabled_ = value;
+    }
+
+    // Controls whether the alpha component of the fragment’s first color output
+    // is replaced with one.
+    bool is_alpha_to_one_enabled() const { return alpha_to_one_enabled_; }
+    void set_alpha_to_one_enabled(bool value) { alpha_to_one_enabled_ = value; }
+
+    // True if fragment shading executes per-sample, otherwise per-fragment.
+    bool is_sample_shading_enabled() const { return sample_shading_enabled_; }
+    void set_sample_shading_enabled(bool value) {
+      sample_shading_enabled_ = value;
+    }
+
+    // The minimum fraction of sample shading.
+    float min_sample_shading() const { return min_sample_shading_; }
+    void set_min_sample_shading(float value) { min_sample_shading_ = value; }
+
+    // TODO(benvanik): sample mask array, each element uint32_t, count is
+    //                 rasterization_samples.
+    // const VkSampleMask* pSampleMask;
+
+   private:
+    SampleCount rasterization_samples_ : kSampleCountBits;
+    bool alpha_to_coverage_enabled_ : 1;
+    bool alpha_to_one_enabled_ : 1;
+    bool sample_shading_enabled_ : 1;
+    float min_sample_shading_;
+  };
+  MultisampleState multisample_state;
+
+  // Determines the stencil comparison function.
+  // R is the masked reference value and S is the masked stored stencil value.
+  enum class CompareOp {
+    // The test never passes.
+    kNever = 0,
+    // The test passes when R < S.
+    kLess = 1,
+    // The test passes when R = S.
+    kEqual = 2,
+    // The test passes when R ≤ S.
+    kLessOrEqual = 3,
+    // The test passes when R > S.
+    kGreater = 4,
+    // The test passes when R ≠ S.
+    kNotEqual = 5,
+    // The test passes when R ≥ S.
+    kGreaterOrEqual = 6,
+    // The test always passes.
+    kAlways = 7,
+  };
+  static constexpr int kCompareOpBits = 3;
+
+  // Indicates what happens to the stored stencil value if this or certain
+  // subsequent tests fail or pass.
+  enum class StencilOp {
+    // Keeps the current value.
+    kKeep = 0,
+    // Sets the value to 0.
+    kZero = 1,
+    // Sets the value to reference.
+    kReplace = 2,
+    // Increments the current value and clamps to the maximum representable
+    // unsigned value.
+    kIncrementAndClamp = 3,
+    // Decrements the current value and clamps to 0.
+    kDecrementAndClamp = 4,
+    // Bitwise-inverts the current value.
+    kInvert = 5,
+    // Increments the current value and wraps to 0 when the maximum value would
+    // have been exceeded.
+    kIncrementAndWrap = 6,
+    // Decrements the current value and wraps to the maximum possible value when
+    // the value would go below 0.
+    kDecrementAndWrap = 7,
+  };
+  static constexpr int kStencilOpBits = 3;
+
+  class StencilOpState {
+   public:
+    StencilOpState() {
+      fail_op_ = StencilOp::kKeep;
+      pass_op_ = StencilOp::kKeep;
+      depth_fail_op_ = StencilOp::kKeep;
+      compare_op_ = CompareOp::kAlways;
+    }
+
+    StencilOp fail_op() const { return fail_op_; }
+    void set_fail_op(StencilOp value) { fail_op_ = value; }
+
+    StencilOp pass_op() const { return pass_op_; }
+    void set_pass_op(StencilOp value) { pass_op_ = value; }
+
+    StencilOp depth_fail_op() const { return depth_fail_op_; }
+    void set_depth_fail_op(StencilOp value) { depth_fail_op_ = value; }
+
+    CompareOp compare_op() const { return compare_op_; }
+    void set_compare_op(CompareOp value) { compare_op_ = value; }
+
+   private:
+    StencilOp fail_op_ : kStencilOpBits;
+    StencilOp pass_op_ : kStencilOpBits;
+    StencilOp depth_fail_op_ : kStencilOpBits;
+    CompareOp compare_op_ : kCompareOpBits;
+  };
+
+  class DepthStencilState {
+   public:
+    DepthStencilState() {
+      depth_test_enabled_ = false;
+      depth_write_enabled_ = false;
+      depth_compare_op_ = CompareOp::kLess;
+      depth_bounds_test_enabled_ = false;
+      stencil_test_enabled_ = false;
+    }
+
+    bool is_depth_test_enabled() const { return depth_test_enabled_; }
+    void set_depth_test_enabled(bool value) { depth_test_enabled_ = value; }
+
+    bool is_depth_write_enabled() const { return depth_write_enabled_; }
+    void set_depth_write_enabled(bool value) { depth_write_enabled_ = value; }
+
+    CompareOp depth_compare_op() const { return depth_compare_op_; }
+    void set_depth_compare_op(CompareOp value) { depth_compare_op_ = value; }
+
+    bool is_depth_bounds_test_enabled() const {
+      return depth_bounds_test_enabled_;
+    }
+    void set_depth_bounds_test_enabled(bool value) {
+      depth_bounds_test_enabled_ = value;
+    }
+
+    bool is_stencil_test_enabled() const { return stencil_test_enabled_; }
+    void set_stencil_test_enabled(bool value) { stencil_test_enabled_ = value; }
+
+    const StencilOpState& stencil_front_state() const {
+      return stencil_front_state_;
+    }
+    void set_stencil_front_state(StencilOpState value) {
+      stencil_front_state_ = value;
+    }
+    const StencilOpState& stencil_back_state() const {
+      return stencil_back_state_;
+    }
+    void set_stencil_back_state(StencilOpState value) {
+      stencil_back_state_ = value;
+    }
+
+   private:
+    bool depth_test_enabled_ : 1;
+    bool depth_write_enabled_ : 1;
+    CompareOp depth_compare_op_ : kCompareOpBits;
+    bool depth_bounds_test_enabled_ : 1;
+    bool stencil_test_enabled_ : 1;
+    StencilOpState stencil_front_state_;
+    StencilOpState stencil_back_state_;
+  };
+  DepthStencilState depth_stencil_state;
+
+  class ColorBlendAttachmentState {
+   public:
+    ColorBlendAttachmentState() {
+      blend_enabled_ = false;
+      src_color_blend_factor_ = BlendFactor::kOne;
+      dst_color_blend_factor_ = BlendFactor::kZero;
+      color_blend_op_ = BlendOp::kAdd;
+      src_alpha_blend_factor_ = BlendFactor::kOne;
+      dst_alpha_blend_factor_ = BlendFactor::kZero;
+      alpha_blend_op_ = BlendOp::kAdd;
+      color_write_mask_ = ColorComponentMask::kRGBA;
+    }
+
+    // Controls whether blending is enabled for the corresponding color
+    // attachment. If blending is not enabled the source fragment’s color for
+    // that attachment is passed through unmodified.
+    bool is_blend_enabled() const { return blend_enabled_; }
+    void set_blend_enabled(bool value) { blend_enabled_ = value; }
+
+    // Selects which blend factor is used to determine the source factors
+    // (Sr,Sg,Sb).
+    BlendFactor src_color_blend_factor() const {
+      return src_color_blend_factor_;
+    }
+    void set_src_color_blend_factor(BlendFactor value) {
+      src_color_blend_factor_ = value;
+    }
+
+    // Selects which blend factor is used to determine the destination factors
+    // (Dr,Dg,Db).
+    BlendFactor dst_color_blend_factor() const {
+      return dst_color_blend_factor_;
+    }
+    void set_dst_color_blend_factor(BlendFactor value) {
+      dst_color_blend_factor_ = value;
+    }
+
+    // Selects which blend operation is used to calculate the RGB values to
+    // write to the color attachment.
+    BlendOp color_blend_op() const { return color_blend_op_; }
+    void set_color_blend_op(BlendOp value) { color_blend_op_ = value; }
+
+    // Selects which blend factor is used to determine the source factor Sa.
+    BlendFactor src_alpha_blend_factor() const {
+      return src_alpha_blend_factor_;
+    }
+    void set_src_alpha_blend_factor(BlendFactor value) {
+      src_alpha_blend_factor_ = value;
+    }
+
+    // Selects which blend factor is used to determine the destination factor
+    // Da.
+    BlendFactor dst_alpha_blend_factor() const {
+      return dst_alpha_blend_factor_;
+    }
+    void set_dst_alpha_blend_factor(BlendFactor value) {
+      dst_alpha_blend_factor_ = value;
+    }
+
+    // Selects which blend operation is use to calculate the alpha values to
+    // write to the color attachment.
+    BlendOp alpha_blend_op() const { return alpha_blend_op_; }
+    void set_alpha_blend_op(BlendOp value) { alpha_blend_op_ = value; }
+
+    // A bitmask selecting which of the R, G, B, and/or A components are enabled
+    // for writing.
+    ColorComponentMask color_write_mask() const { return color_write_mask_; }
+    void set_color_write_mask(ColorComponentMask value) {
+      color_write_mask_ = value;
+    }
+
+   private:
+    bool blend_enabled_ : 1;
+    BlendFactor src_color_blend_factor_ : kBlendFactorBits;
+    BlendFactor dst_color_blend_factor_ : kBlendFactorBits;
+    BlendOp color_blend_op_ : kBlendOpBits;
+    BlendFactor src_alpha_blend_factor_ : kBlendFactorBits;
+    BlendFactor dst_alpha_blend_factor_ : kBlendFactorBits;
+    BlendOp alpha_blend_op_ : kBlendOpBits;
+    ColorComponentMask color_write_mask_ : kColorComponentMaskBits;
+  };
+
+  class ColorBlendState {
+   public:
+    ColorBlendState() {}
+
+    // An array of states, one for each subpass attachment.
+    // The indices match with the subpass color attachments.
+    FixedVector<ColorBlendAttachmentState, kMaxColorAttachments> attachments;
+
+   private:
+  };
+  ColorBlendState color_blend_state;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_RENDER_STATE_H_

--- a/xrtl/gfx/resource.h
+++ b/xrtl/gfx/resource.h
@@ -1,0 +1,245 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_RESOURCE_H_
+#define XRTL_GFX_RESOURCE_H_
+
+#include <cstdint>
+
+#include "xrtl/base/ref_ptr.h"
+
+namespace xrtl {
+namespace gfx {
+
+class Resource;
+
+// A memory mapping RAII object.
+// The mapping will stay active until this is reset.
+template <typename T>
+class MappedMemory {
+ public:
+  typedef const T* MappedMemory<T>::*unspecified_bool_type;
+
+  MappedMemory() = default;
+
+  MappedMemory(ref_ptr<Resource> resource, size_t byte_offset,
+               size_t byte_length, size_t size, T* data)
+      : resource_(resource),
+        byte_offset_(byte_offset),
+        byte_length_(byte_length),
+        size_(size),
+        data_(data) {}
+
+  ~MappedMemory() { reset(); }
+
+  // The resource that this mapping references.
+  ref_ptr<Resource> resource() const { return resource_; }
+  // Offset, in bytes, into the resource allocation.
+  size_t byte_offset() const noexcept { return byte_offset_; }
+  // Length, in bytes, of the resource mapping.
+  // This may be larger than the originally requested length due to alignment.
+  size_t byte_length() const noexcept { return byte_length_; }
+
+  // True if the mapping is empty.
+  bool empty() const noexcept { return size_ == 0; }
+  // The size of the mapping as requested in elements.
+  size_t size() const noexcept { return size_; }
+  // Returns a pointer to the mapped memory.
+  // This will be nullptr if the mapping failed.
+  const T* data() const noexcept { return data_; }
+
+  // Accesses an element in the mapped memory.
+  // Must be called with a valid index in [0, size()).
+  const T& operator[](size_t i) const noexcept { return data_[i]; }
+
+  // Supports boolean expression evaluation.
+  operator unspecified_bool_type() const {
+    return byte_length_ > 0 ? &MappedMemory::data_ : 0;
+  }
+  // Supports unary expression evaluation.
+  bool operator!() const { return byte_length_ == 0; }
+
+  // Invalidates all mapping non-coherent memory from the host caches.
+  void Invalidate();
+  // Invalidates a range of non-coherent elements from the host caches.
+  void Invalidate(size_t element_offset, size_t element_length);
+
+  // Flushes all mapping non-coherent memory from the host caches.
+  void Flush();
+  // Flushes a range of non-coherent elements from the host caches.
+  void Flush(size_t element_offset, size_t element_length);
+
+  // Unmaps the mapped memory.
+  // The memory will not be implicitly flushed when unmapping.
+  void reset();
+
+ private:
+  ref_ptr<Resource> resource_;
+  size_t byte_offset_ = 0;
+  size_t byte_length_ = 0;
+  size_t size_ = 0;
+  T* data_ = nullptr;
+};
+
+// Base type for allocated resources.
+class Resource : public RefObject<Resource> {
+ public:
+  virtual ~Resource() = default;
+
+  // Size of the resource memory allocation in bytes.
+  // This may be rounded up from the originally requested size or the ideal
+  // size for the resource based on device restrictions.
+  size_t allocation_size() const { return allocation_size_; }
+
+  // Reads a block of data from the resource at the given offset.
+  //
+  // Returns false if the read could not be performed; either the bounds are
+  // out of range or the memory type does not support reading in this way.
+  virtual bool ReadData(size_t source_offset, void* data,
+                        size_t data_length) = 0;
+
+  // Writes a block of data into the resource at the given offset.
+  //
+  // Returns false if the write could not be performed; either the bounds are
+  // out of range or the memory type does not support writing in this way.
+  virtual bool WriteData(size_t target_offset, const void* data,
+                         size_t data_length) = 0;
+
+  // Maps the resource memory for direct access from the host.
+  // This requires that the resource was allocated with
+  // MemoryType::kHostVisible.
+  //
+  // If MemoryType::kHostCoherent was not specified the explicit
+  // InvalidateMappedMemory and FlushMappedMemory must be used to control
+  // visibility of the data on the device. If MemoryType::kHostCached
+  // is not set callers should not attempt to read from the mapped memory, as
+  // doing so may produce undefined results and/or ultra slow reads.
+  //
+  // This allows mapping the memory as a C++ type. Care must be taken to ensure
+  // the data layout in C++ matches the expected data layout in the shaders that
+  // consume this data. For simple primitives like uint8_t or float this is
+  // usually not a problem, however struct packing may have many restrictions.
+  //
+  // The returned mapping should be unmapped when it is no longer required.
+  // Devices may conditionally support persistent mappings that can be left
+  // mapped for longer, however doing so has a cost. Unmapping does not
+  // implicitly flush.
+  //
+  // Returns nullptr if the memory could not be mapped due to mapping
+  // exhaustion, invalid arguments, or unsupported memory types.
+  //
+  // Usage:
+  //  MappedMemory memory = buffer->MapMemory<MyStruct>();
+  //  memory[5].foo = 3;
+  //  std::memcpy(memory.data(), source_data, memory.size());
+  //  memory.reset();
+  template <typename T>
+  MappedMemory<T> MapMemory(size_t element_offset, size_t element_length) {
+    size_t byte_offset = element_offset * sizeof(T);
+    size_t byte_length = element_length * sizeof(T);
+    void* data = nullptr;
+    if (!MapMemory(&byte_offset, &byte_length, &data)) {
+      return {};
+    }
+    return {this, byte_offset, byte_length, element_length, data};
+  }
+  template <typename T>
+  MappedMemory<T> MapMemory() {
+    return MapMemory<T>(0, allocation_size() / sizeof(T));
+  }
+
+  // Invalidates ranges of non-coherent memory from the host caches.
+  // Use this before reading from non-coherent memory.
+  // This guarantees that device writes to the memory ranges provided are
+  // visible on the host.
+  // This is only required for memory types without kHostCoherent set.
+  virtual void InvalidateMappedMemory(size_t byte_offset,
+                                      size_t byte_length) = 0;
+  void InvalidateMappedMemory() {
+    InvalidateMappedMemory(0, allocation_size());
+  }
+
+  // Flushes ranges of non-coherent memory from the host caches.
+  // Use this after writing to non-coherent memory.
+  // This guarantees that host writes to the memory ranges provided are made
+  // available for device access.
+  // This is only required for memory types without kHostCoherent set.
+  virtual void FlushMappedMemory(size_t byte_offset, size_t byte_length) = 0;
+  void FlushMappedMemory() { FlushMappedMemory(0, allocation_size()); }
+
+ protected:
+  template <typename T>
+  friend class MappedMemory;
+
+  explicit Resource(size_t allocation_size)
+      : allocation_size_(allocation_size) {}
+
+  // Maps memory directly.
+  // The byte offset and byte length may be adjusted for device alignment.
+  // The output data pointer will be properly aligned to the start of the data.
+  // Returns false if the memory could not be mapped.
+  virtual bool MapMemory(size_t* byte_offset, size_t* byte_length,
+                         void** out_data) = 0;
+
+  // Unmaps previously mapped memory.
+  virtual void UnmapMemory(size_t byte_offset, size_t byte_length,
+                           void* data) = 0;
+
+  size_t allocation_size_ = 0;
+};
+
+template <typename T>
+void MappedMemory<T>::Invalidate() {
+  if (resource_) {
+    resource_->InvalidateMappedMemory(byte_offset_, byte_length_);
+  }
+}
+
+template <typename T>
+void MappedMemory<T>::Invalidate(size_t element_offset, size_t element_length) {
+  if (resource_) {
+    resource_->InvalidateMappedMemory(byte_offset_ + element_offset * sizeof(T),
+                                      element_length * sizeof(T));
+  }
+}
+
+template <typename T>
+void MappedMemory<T>::Flush() {
+  if (resource_) {
+    resource_->FlushMappedMemory(byte_offset_, byte_length_);
+  }
+}
+
+template <typename T>
+void MappedMemory<T>::Flush(size_t element_offset, size_t element_length) {
+  if (resource_) {
+    resource_->FlushMappedMemory(byte_offset_ + element_offset * sizeof(T),
+                                 element_length * sizeof(T));
+  }
+}
+
+template <typename T>
+void MappedMemory<T>::reset() {
+  if (resource_) {
+    resource_->UnmapMemory(byte_offset_, byte_length_, data_);
+    resource_ = nullptr;
+    byte_offset_ = byte_length_ = size_ = 0;
+    data_ = nullptr;
+  }
+}
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_RESOURCE_H_

--- a/xrtl/gfx/resource_set.h
+++ b/xrtl/gfx/resource_set.h
@@ -1,0 +1,109 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_RESOURCE_SET_H_
+#define XRTL_GFX_RESOURCE_SET_H_
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "xrtl/base/array_view.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/buffer.h"
+#include "xrtl/gfx/image.h"
+#include "xrtl/gfx/image_view.h"
+#include "xrtl/gfx/pipeline_layout.h"
+#include "xrtl/gfx/sampler.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A set of bindings for a particular PipelineLayout.
+// Bindings can be used across multiple Pipelines that share the same layout.
+class ResourceSet : public RefObject<ResourceSet> {
+ public:
+  // Describes a single binding slot within the resource set.
+  struct Binding {
+    // Array element children.
+    std::vector<Binding> elements;
+
+    // Buffer bound to the slot, or nullptr for none.
+    ref_ptr<Buffer> buffer;
+    // The offset in bytes from the start of buffer. Access to buffer memory via
+    // this descriptor uses addressing that is relative to this starting offset.
+    size_t buffer_offset = 0;
+    // The size in bytes that is used for this descriptor update, or -1 to use
+    // the range from offset to the end of the buffer.
+    size_t buffer_length = -1;
+
+    // Image view.
+    ref_ptr<ImageView> image_view;
+    // Layout the image is in when bound.
+    Image::Layout image_layout = Image::Layout::kGeneral;
+
+    // Sampler used for the image.
+    ref_ptr<Sampler> sampler;
+
+    Binding() = default;
+
+    // Binding slot used for arrays of bindings.
+    Binding(ArrayView<Binding> elements)  // NOLINT
+        : elements(elements) {}
+
+    // Binding slot used for kUniformBuffer and kStorageBuffer.
+    Binding(ref_ptr<Buffer> buffer)  // NOLINT
+        : buffer(std::move(buffer)) {}
+    Binding(ref_ptr<Buffer> buffer, size_t offset, size_t length)
+        : buffer(std::move(buffer)),
+          buffer_offset(offset),
+          buffer_length(length) {}
+
+    // Binding slot used for kSampledImage, kStorageImage, and kInputAttachment.
+    Binding(ref_ptr<ImageView> image_view, Image::Layout image_layout)
+        : image_view(std::move(image_view)), image_layout(image_layout) {}
+
+    // Binding slot used for kSampler.
+    Binding(ref_ptr<Sampler> sampler)  // NOLINT
+        : sampler(std::move(sampler)) {}
+
+    // Binding slot used for kCombinedImageSampler.
+    Binding(ref_ptr<ImageView> image_view, Image::Layout image_layout,
+            ref_ptr<Sampler> sampler)
+        : image_view(std::move(image_view)),
+          image_layout(image_layout),
+          sampler(std::move(sampler)) {}
+  };
+
+  virtual ~ResourceSet() = default;
+
+  // Layout the pipeline binding set uses.
+  ref_ptr<PipelineLayout> layout() const { return layout_; }
+
+  // All bindings for the resource set.
+  const std::vector<Binding>& bindings() const { return bindings_; }
+
+ protected:
+  explicit ResourceSet(ref_ptr<PipelineLayout> layout,
+                       ArrayView<Binding> bindings)
+      : layout_(std::move(layout)), bindings_(bindings) {}
+
+  ref_ptr<PipelineLayout> layout_;
+  std::vector<Binding> bindings_;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_RESOURCE_SET_H_

--- a/xrtl/gfx/sampler.h
+++ b/xrtl/gfx/sampler.h
@@ -1,0 +1,102 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_SAMPLER_H_
+#define XRTL_GFX_SAMPLER_H_
+
+#include "xrtl/base/ref_ptr.h"
+
+namespace xrtl {
+namespace gfx {
+
+class Sampler : public RefObject<Sampler> {
+ public:
+  // Specifies filters used for image lookups.
+  enum class Filter {
+    kNearest = 0,
+    kLinear = 1,
+  };
+
+  // Specifies filters used for mipmap lookups.
+  enum class MipmapMode {
+    kNearest = 0,
+    kLinear = 1,
+  };
+
+  // Specifies behavior of sampling with image coordinates outside an image.
+  enum class AddressMode {
+    kRepeat = 0,
+    kMirroredRepeat = 1,
+    kClampToEdge = 2,
+    kClampToBorder = 3,
+  };
+
+  // Predefined border color modes.
+  enum class BorderColor {
+    kTransparentBlackFloat = 0,
+    kTransparentBlackInt = 1,
+    kOpaqueBlackFloat = 2,
+    kOpaqueBlackInt = 3,
+    kOpaqueWhiteFloat = 4,
+    kOpaqueWhiteInt = 5,
+  };
+
+  // All sampler parameters.
+  struct Params {
+    // The magnification filter to apply to lookups.
+    Filter mag_filter = Filter::kNearest;
+    // The minification filter to apply to lookups.
+    Filter min_filter = Filter::kNearest;
+    // The mipmap filter to apply to lookups.
+    MipmapMode mipmap_mode = MipmapMode::kNearest;
+
+    // The addressing mode for lookups outside [0..1] range for each coordinate.
+    AddressMode address_mode_u = AddressMode::kRepeat;
+    AddressMode address_mode_v = AddressMode::kRepeat;
+    AddressMode address_mode_w = AddressMode::kRepeat;
+
+    // The bias to be added to mipmap LOD calculation and bias provided by
+    // image sampling functions.
+    float mip_lod_bias = 0.0f;
+    // Values used to clamp the computed level-of-detail value.
+    float min_lod = 0.0f;
+    float max_lod = 0.0f;
+
+    // True to enable anisotropic filtering.
+    bool anisotropy_enable = false;
+    // Anisotropy value clamp.
+    float max_anisotropy = 1.0f;
+
+    // Predefined border color used when kClampToBorder is enabled.
+    BorderColor border_color = BorderColor::kTransparentBlackFloat;
+
+    // TODO(benvanik): verify this can be supported everywhere.
+    // bool unnormalized_coordinates = false;
+  };
+
+  virtual ~Sampler() = default;
+
+  // Sampler parameters.
+  const Params& params() const { return params_; }
+
+ protected:
+  explicit Sampler(Params params) : params_(params) {}
+
+  Params params_;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_SAMPLER_H_

--- a/xrtl/gfx/shader_module.h
+++ b/xrtl/gfx/shader_module.h
@@ -1,0 +1,42 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_SHADER_MODULE_H_
+#define XRTL_GFX_SHADER_MODULE_H_
+
+#include "xrtl/base/ref_ptr.h"
+
+namespace xrtl {
+namespace gfx {
+
+// A module of shader code.
+// Each module may contain multiple entry points that can be used by pipelines.
+class ShaderModule : public RefObject<ShaderModule> {
+ public:
+  // Describes the format of shader module data.
+  enum class DataFormat {
+    // Standard SPIR-V.
+    kSpirV,
+  };
+
+  virtual ~ShaderModule() = default;
+
+ protected:
+  ShaderModule() = default;
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_SHADER_MODULE_H_

--- a/xrtl/gfx/swap_chain.h
+++ b/xrtl/gfx/swap_chain.h
@@ -1,0 +1,211 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_SWAP_CHAIN_H_
+#define XRTL_GFX_SWAP_CHAIN_H_
+
+#include <chrono>
+#include <utility>
+#include <vector>
+
+#include "xrtl/base/geometry.h"
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/command_buffer.h"
+#include "xrtl/gfx/image.h"
+#include "xrtl/gfx/image_view.h"
+#include "xrtl/gfx/pixel_format.h"
+#include "xrtl/gfx/queue_fence.h"
+
+namespace xrtl {
+namespace gfx {
+
+// Presentation swap chain.
+// Manages a queue of Images that are used to present render output to a
+// system surface. Multiple swap chains may exist in an application (one per
+// surface), each with their own queue.
+//
+// At the start of a frame the application dequeues an image from the swap
+// chain via AcquireNextImage. This may block waiting for images to
+// become available from the system. Once returned, the image view can be used
+// in an image for rendering. Any command buffer that uses the image view
+// must wait on submit for the fence passed to AcquireNextImage signalling that
+// the image is available for use.
+//
+// A the end of a frame the application enqueues the image for
+// presentation in the swap chain with PresentImage. The image must have been
+// transitioned to Layout::kPresentSource. After enqueuing for present the
+// image must not be used until the next time it is acquired from the swap
+// chain with AcquireNextImage.
+//
+// Usage:
+//  auto command_buffer = context->CreateCommandBuffer(kRender);
+//  // Acquire a new image, possibly blocking until one is ready:
+//  swap_chain->AcquireNextImage(image_ready_fence, &image_view);
+//  // Wrap image view in an image. Do this once and cache.
+//  auto framebuffer = WrapFramebuffer(image_view);
+//  // Use the framebuffer:
+//  DoRendering(command_buffer, framebuffer);
+//  // Submit for rendering into the framebuffer.
+//  context_->Submit(image_ready_fence, command_buffer, rendered_fence);
+//  // NOTE: command buffer is submitted here by the swap chain!
+//  swap_chain->PresentImage(std::move(rendered_fence),
+//                           std::move(image_view));
+class SwapChain : public RefObject<SwapChain> {
+ public:
+  virtual ~SwapChain() = default;
+
+  // Defines the presentation queueing mode used by the swap chain.
+  //
+  // See section 20 here for more information:
+  // https://software.intel.com/en-us/articles/api-without-secrets-introduction-to-vulkan-part-2#_Toc445674479
+  enum class PresentMode {
+    // Queue up to 1 pending image at a time.
+    // This prevents tearing but may introduce frame skips (if the compositor
+    // runs slower than images are enqueued).
+    //
+    // Maps to VK_PRESENT_MODE_MAILBOX_KHR.
+    kLowLatency,
+    // Immediately present the swap chain contents.
+    // This may cause tearing as the image being used to scan-out the
+    // display may be replaced with a newly-enqueued images. This is the
+    // classic novsync mode.
+    //
+    // Maps to VK_PRESENT_MODE_IMMEDIATE_KHR.
+    kImmediate,
+    // Queues the frame buffers for FIFO processing.
+    // This is like the classic GL present mode in that the compositor ensures
+    // all images queued are displayed even if it is running slower than
+    // they are being enqueued.
+    //
+    // Maps to VK_PRESENT_MODE_FIFO_KHR.
+    kFifo,
+  };
+
+  // Presentation mode used by the compositor defining the queuing mode of the
+  // swap chain.
+  PresentMode present_mode() const { return present_mode_; }
+  // Maximum number of images in the swap chain queue.
+  // This is almost always 2 (for double-buffering).
+  int image_count() const { return image_count_; }
+
+  // Dimensions of the swap chain images in pixels.
+  Size2D size() const { return size_; }
+
+  // Defines the result of a swap chain resize operation.
+  enum class ResizeResult {
+    // Resize completed successfully and the new images are available for
+    // use immediately.
+    kSuccess,
+    // Memory was not available to allocate the new images. The old
+    // images may no longer be valid. Consider this fatal to the
+    // swap chain.
+    kOutOfMemory,
+    // The device was lost before or during resize.
+    kDeviceLost,
+  };
+
+  // Resizes the images to the given dimensions.
+  // The contents of the images are undefined after resizing. The queue
+  // images must not currently be in use by any in-flight command buffer.
+  // This may fail if memory is not available for the new frame buffers or the
+  // device is lost. If it fails the contents and validity of the swap chain are
+  // both undefined and it's best to fail up.
+  virtual ResizeResult Resize(Size2D new_size) = 0;
+
+  // Defines the result of a dequeue image operation.
+  enum class AcquireResult {
+    // An image was successfully dequeued.
+    kSuccess,
+    // The target swap chain surface has been resized and the swap chain no
+    // longer matches. Resize the swap chain before continuing to render.
+    kResizeRequired,
+    // The specified timeout elapsed while waiting for an image to become
+    // available.
+    kTimeout,
+    // The device was lost before or during the wait to dequeue an image.
+    kDeviceLost,
+  };
+
+  // Dequeues an image from the swap chain image pool.
+  // If none is available the call may block until one is unless a timeout is
+  // specified.
+  //
+  // On success the returned image will be in Layout::kUndefined. The wait fence
+  // will be signaled asynchronously when a command buffer may be submitted that
+  // uses the image as a framebuffer target.
+  //
+  // The returned image should be presented with PresentImage as
+  // soon as possible. Do not present out of order.
+  virtual AcquireResult AcquireNextImage(
+      std::chrono::milliseconds timeout_millis,
+      ref_ptr<QueueFence> signal_queue_fence,
+      ref_ptr<ImageView>* out_image_view) = 0;
+  AcquireResult AcquireNextImage(ref_ptr<QueueFence> signal_queue_fence,
+                                 ref_ptr<ImageView>* out_image_view) {
+    return AcquireNextImage(std::chrono::milliseconds::max(),
+                            std::move(signal_queue_fence), out_image_view);
+  }
+
+  // Defines the result of an enqueue image operation.
+  enum class PresentResult {
+    // The image was enqueued for presentation.
+    kSuccess,
+    // The target swap chain surface has been resized and the swap chain no
+    // longer matches. Resize the swap chain before continuing to render.
+    kResizeRequired,
+    // The device was lost before or during the enqueue operation.
+    kDeviceLost,
+  };
+
+  // Enqueues the given image for presentation on the swap chain.
+  // The behavior of the enqueue operation depends on the present mode.
+  // This must only be used with an image returned from the previous call to
+  // AcquireNextImage.
+  //
+  // The provided wait fence must be used to signal that all operations that
+  // use the image have completed and that the image has been transitioned to
+  // Layout::kPresentSource.
+  //
+  // The image must not be used again until it is dequeued from
+  // AcquireNextImage even if this function fails.
+  //
+  // If an absolute present time is specified (as SystemClock::now_utc_millis())
+  // the compositor may wait to display it on the screen until that time. Not
+  // all implementations support this so it should only be treated as a hint.
+  virtual PresentResult PresentImage(
+      ref_ptr<QueueFence> wait_queue_fence, ref_ptr<ImageView> image_view,
+      std::chrono::milliseconds present_time_utc_millis) = 0;
+  PresentResult PresentImage(ref_ptr<QueueFence> wait_queue_fence,
+                             ref_ptr<ImageView> image_view) {
+    return PresentImage(std::move(wait_queue_fence), std::move(image_view),
+                        std::chrono::milliseconds::min());
+  }
+
+ protected:
+  SwapChain(PresentMode present_mode, int image_count,
+            ArrayView<PixelFormat> pixel_formats)
+      : present_mode_(present_mode),
+        image_count_(image_count),
+        pixel_formats_(pixel_formats) {}
+
+  PresentMode present_mode_ = PresentMode::kLowLatency;
+  int image_count_ = 0;
+  std::vector<PixelFormat> pixel_formats_;
+  Size2D size_{0, 0};
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_SWAP_CHAIN_H_


### PR DESCRIPTION
Unifies vulkan, metal, and d3d12, mostly designed like vulkan to make code
porting easier.

Many vulkan rough-edges will likely be removed or simplified based on our
usage. Transitioning images is an example of a nasty thing in vulkan that
would be nice to simplify a bit for easier usage.