### PR TITLE
Return relative path when no absolute path is found.

### DIFF
--- a/xrtl/testing/file_manifest.cc
+++ b/xrtl/testing/file_manifest.cc
@@ -14,6 +14,7 @@
 
 #include "xrtl/testing/file_manifest.h"
 
+#include <algorithm>
 #include <fstream>
 
 namespace xrtl {
@@ -49,7 +50,7 @@ void FileManifest::ParseFromManifest(const std::string& executable_path) {
   manifest_file_stream.close();
 }
 
-StringView FileManifest::ResolveAbsolutePath(StringView relative_path) {
+StringView FileManifest::ResolvePath(StringView relative_path) {
   std::string target_path = std::string(std::getenv("TEST_WORKSPACE")) + "/" +
                             std::string(relative_path);
   for (auto file_path_pair : file_paths_map) {
@@ -60,7 +61,7 @@ StringView FileManifest::ResolveAbsolutePath(StringView relative_path) {
     }
   }
 
-  return "";
+  return relative_path;
 }
 
 }  // namespace testing

--- a/xrtl/testing/file_manifest.h
+++ b/xrtl/testing/file_manifest.h
@@ -32,10 +32,11 @@ class FileManifest {
   // Call this during test setup.
   static void ParseFromManifest(const std::string& executable_path);
 
-  // Gets the absolute path for the provided test data relative path or empty
-  // string if that exact relative path does not exist in the runfiles MANIFEST.
+  // Gets the path for the provided test data relative path.
+  // Returns the input relative path without modifications if the exact relative
+  // path is not found in the runfiles MANIFEST.
   // Only files specified in the "data" field of tests will be available here.
-  static StringView ResolveAbsolutePath(StringView relative_path);
+  static StringView ResolvePath(StringView relative_path);
 
  private:
   static std::vector<std::pair<std::string, std::string>> file_paths_map;

--- a/xrtl/testing/image_loader.cc
+++ b/xrtl/testing/image_loader.cc
@@ -14,14 +14,14 @@
 
 #include "xrtl/testing/image_loader.h"
 
-#include <utility>
-
 // TODO(scotttodd): Move this to some build magic and/or a .cc file
 #define STBI_NO_LINEAR  // no loadf
 #define STBI_NO_HDR     // no hdr conversion
 #define STBI_ONLY_PNG   // only .png support
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
+
+#include <utility>
 
 #include "xrtl/base/logging.h"
 #include "xrtl/testing/file_manifest.h"
@@ -32,7 +32,7 @@ namespace testing {
 Image ImageLoader::LoadImage(StringView path, int image_channels) {
   Image image;
   ImageDataPtr image_data = {
-      stbi_load(FileManifest::ResolveAbsolutePath(path).data(), &image.width,
+      stbi_load(FileManifest::ResolvePath(path).data(), &image.width,
                 &image.height, &image.channels, image_channels),
       [](uint8_t* data) { stbi_image_free(data); }};
   image.data = std::move(image_data);


### PR DESCRIPTION
On MacOS, TEST_SRCDIR points to a bazel-sandbox path where the MANIFEST file can't be found/opened but the relative paths work just fine.