### PR TITLE
Swiftshader on Windows.

### DIFF
--- a/xrtl/gfx/BUILD
+++ b/xrtl/gfx/BUILD
@@ -100,14 +100,8 @@ cc_library(
 )
 
 cc_library(
-    name = "context_factory",
-    srcs = ["context_factory.cc"],
-    hdrs = ["context_factory.h"],
-    deps = [
-        ":context_factory_hdrs",
-        "//xrtl/base:flags",
-        "//xrtl/base:logging",
-    ] + select({
+    name = "port_context_factory",
+    deps = select({
         "//xrtl/tools/target_platform:android": [],
         "//xrtl/tools/target_platform:emscripten": [],
         "//xrtl/tools/target_platform:ios": [],
@@ -116,6 +110,27 @@ cc_library(
         ],
         "//xrtl/tools/target_platform:macos": [],
         "//xrtl/tools/target_platform:windows": [],
+    }),
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "context_factory",
+    srcs = ["context_factory.cc"],
+    hdrs = ["context_factory.h"],
+    deps = [
+        ":context_factory_hdrs",
+        "//xrtl/base:flags",
+        "//xrtl/base:logging",
+    ] + select({
+        # Always use EGL when targeting swiftshader, and otherwise use the
+        # port's default implementation.
+        "//xrtl/tools/target_config:swiftshader": [
+            "//xrtl/gfx/es3:es3_context_factory",
+        ],
+        "//conditions:default": [
+            ":port_context_factory",
+        ],
     }),
 )
 

--- a/xrtl/gfx/es3/BUILD
+++ b/xrtl/gfx/es3/BUILD
@@ -208,14 +208,8 @@ cc_library(
 )
 
 cc_library(
-    name = "es3_platform_context",
-    srcs = ["es3_platform_context.cc"],
-    hdrs = ["es3_platform_context.h"],
-    deps = [
-        ":es3_common",
-        "//xrtl/base:ref_ptr",
-        "//xrtl/base/threading:thread",
-    ] + select({
+    name = "port_platform_context",
+    deps = select({
         "//xrtl/tools/target_platform:android": [],
         "//xrtl/tools/target_platform:emscripten": [],
         "//xrtl/tools/target_platform:ios": [],
@@ -224,6 +218,27 @@ cc_library(
         ],
         "//xrtl/tools/target_platform:macos": [],
         "//xrtl/tools/target_platform:windows": [],
+    }),
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "es3_platform_context",
+    srcs = ["es3_platform_context.cc"],
+    hdrs = ["es3_platform_context.h"],
+    deps = [
+        ":es3_common",
+        "//xrtl/base:ref_ptr",
+        "//xrtl/base/threading:thread",
+    ] + select({
+        # Always use EGL when targeting swiftshader, and otherwise use the
+        # port's default implementation.
+        "//xrtl/tools/target_config:swiftshader": [
+            "//xrtl/port/common/gfx/es3:egl_platform_context",
+        ],
+        "//conditions:default": [
+            ":port_platform_context",
+        ],
     }),
 )
 
@@ -319,6 +334,21 @@ cc_library(
 )
 
 cc_library(
+    name = "port_swap_chain",
+    deps = select({
+        "//xrtl/tools/target_platform:android": [],
+        "//xrtl/tools/target_platform:emscripten": [],
+        "//xrtl/tools/target_platform:ios": [],
+        "//xrtl/tools/target_platform:linux": [
+            "//xrtl/port/common/gfx/es3:egl_swap_chain",
+        ],
+        "//xrtl/tools/target_platform:macos": [],
+        "//xrtl/tools/target_platform:windows": [],
+    }),
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
     name = "es3_swap_chain",
     srcs = ["es3_swap_chain.cc"],
     hdrs = ["es3_swap_chain.h"],
@@ -329,14 +359,14 @@ cc_library(
         "//xrtl/gfx:swap_chain",
         "//xrtl/ui:control",
     ] + select({
-        "//xrtl/tools/target_platform:android": [],
-        "//xrtl/tools/target_platform:emscripten": [],
-        "//xrtl/tools/target_platform:ios": [],
-        "//xrtl/tools/target_platform:linux": [
+        # Always use EGL when targeting swiftshader, and otherwise use the
+        # port's default implementation.
+        "//xrtl/tools/target_config:swiftshader": [
             "//xrtl/port/common/gfx/es3:egl_swap_chain",
         ],
-        "//xrtl/tools/target_platform:macos": [],
-        "//xrtl/tools/target_platform:windows": [],
+        "//conditions:default": [
+            ":port_swap_chain",
+        ],
     }),
 )
 

--- a/xrtl/port/common/gfx/es3/BUILD
+++ b/xrtl/port/common/gfx/es3/BUILD
@@ -49,7 +49,10 @@ cc_library(
             "-ldl",
         ],
         "//xrtl/tools/target_platform:macos": [],
-        "//xrtl/tools/target_platform:windows": [],
+        "//xrtl/tools/target_platform:windows": [
+            "-Wl,libEGL.lib",
+            "-Wl,libGLESv2.lib",
+        ],
     }),
 )
 


### PR DESCRIPTION
This is not directly usable until bazel supports implicit linking:
https://github.com/bazelbuild/bazel/issues/3311

Until then, copying libEGL.lib and the dlls to random paths works.
Will add docs when it gets a little more baked.