### PR TITLE
Changing the TimerDisplayLink to use a dedicated thread.

### DIFF
--- a/xrtl/port/common/ui/BUILD
+++ b/xrtl/port/common/ui/BUILD
@@ -13,6 +13,7 @@ cc_library(
         "//xrtl/base:logging",
         "//xrtl/base:system_clock",
         "//xrtl/base/threading:message_loop",
+        "//xrtl/base/threading:thread",
         "//xrtl/ui:display_link",
     ],
 )

--- a/xrtl/port/windows/ui/win32_control.cc
+++ b/xrtl/port/windows/ui/win32_control.cc
@@ -735,11 +735,11 @@ LRESULT Win32Control::WndProc(HWND hwnd, UINT message, WPARAM w_param,
         is_suspended_ = false;
         PostSuspendChanged(is_suspended_);
         bounds_ = QueryBounds();
-        CheckMonitorChanged();
         PostResized(bounds_);
         OnFocusChanged(is_focused_);
         PostFocusChanged(is_focused_);
       }
+      CheckMonitorChanged();
       break;
     }
 
@@ -767,13 +767,13 @@ LRESULT Win32Control::WndProc(HWND hwnd, UINT message, WPARAM w_param,
           is_suspended_ = false;
           PostSuspendChanged(is_suspended_);
           bounds_ = QueryBounds();
-          CheckMonitorChanged();
           PostResized(bounds_);
           OnFocusChanged(is_focused_);
           PostFocusChanged(is_focused_);
           break;
         }
       }
+      CheckMonitorChanged();
       break;
     }
 

--- a/xrtl/ui/display_link.h
+++ b/xrtl/ui/display_link.h
@@ -53,6 +53,12 @@ class DisplayLink : public RefObject<DisplayLink> {
 
   virtual ~DisplayLink() = default;
 
+  // True if the callbacks from this DisplayLink are accurate.
+  // Some implementations are unable to provide high resolution timing or direct
+  // system vsync listening. If that is the case it's recommended to instead
+  // use dedicated render threads and blocking on swap chain presents.
+  virtual bool is_accurate() = 0;
+
   // The maximum number of frames/second that the display can support.
   // For example, 60. This may change during execution if the parent control
   // is moved to other displays.
@@ -81,6 +87,11 @@ class DisplayLink : public RefObject<DisplayLink> {
   // the kLowLatency constant for the preferred frame rate. The kMaxDisplayRate
   // constant can be used to allow the link to adjust its rate based on the
   // current display of the control.
+  //
+  // Callbacks will be executed on an arbitrary thread depending on
+  // implementation. This may mean the calling thread (if it has a MessageLoop)
+  // or others. Always ensure the callback either marshals to an appropriate
+  // thread or ensures resources are guarded.
   //
   // This is safe to call from any thread.
   virtual void Start(std::function<void(std::chrono::microseconds)> callback,

--- a/xrtl/ui/imgui_overlay_demo.cc
+++ b/xrtl/ui/imgui_overlay_demo.cc
@@ -142,7 +142,7 @@ class ImGuiOverlayDemo : private Control::Listener {
     auto framebuffer_ready_fence = context_->CreateQueueFence();
     ref_ptr<ImageView> framebuffer_image_view;
     auto acquire_result = swap_chain_->AcquireNextImage(
-        std::chrono::milliseconds(2), framebuffer_ready_fence,
+        std::chrono::milliseconds(16), framebuffer_ready_fence,
         &framebuffer_image_view);
     switch (acquire_result) {
       case SwapChain::AcquireResult::kSuccess:
@@ -238,8 +238,9 @@ class ImGuiOverlayDemo : private Control::Listener {
   void OnCreated(ref_ptr<Control> target) override {
     LOG(INFO) << "OnCreated";
     if (!CreateContext() || !CreateImGuiOverlay()) {
-      LOG(ERROR) << "Failed to launch example";
+      LOG(ERROR) << "Failed to initialize graphics resources";
       done_event_->Set();
+      return;
     }
 
     // Start the frame loop.
@@ -252,6 +253,7 @@ class ImGuiOverlayDemo : private Control::Listener {
   void OnDestroying(ref_ptr<Control> target) override {
     LOG(INFO) << "OnDestroying";
 
+    target->display_link()->Stop();
     if (swap_chain_) {
       swap_chain_->DiscardPendingPresents();
     }


### PR DESCRIPTION
This allows for better timing characteristics and removes the variance in
timings due to using the MessageLoop for rendering.

Real apps could have their own threading setup and just do a sync call from
the callback; the demos just draw right in that thread.