### PR TITLE
Suspending display link on monitor power off/lock screen.

### DIFF
--- a/xrtl/port/windows/ui/BUILD
+++ b/xrtl/port/windows/ui/BUILD
@@ -9,6 +9,9 @@ cc_library(
     name = "win32_control",
     srcs = ["win32_control.cc"],
     hdrs = ["win32_control.h"],
+    linkopts = [
+        "-Wl,wtsapi32.lib",
+    ],
     deps = [
         "//xrtl/base:logging",
         "//xrtl/base/threading:event",

--- a/xrtl/port/windows/ui/win32_control.h
+++ b/xrtl/port/windows/ui/win32_control.h
@@ -66,6 +66,7 @@ class Win32Control : public Control {
   bool BeginDestroy();
   bool EndDestroy();
 
+  void CheckScreensaverChanged();
   void CheckMonitorChanged();
   Rect2D QueryBounds();
 
@@ -92,6 +93,11 @@ class Win32Control : public Control {
   Rect2D bounds_{{0, 0}, {128, 128}};
   gfx::rgba8_t background_color_;
   bool is_cursor_visible_ = true;
+
+  // State tracking for screensaver and system power state.
+  bool is_session_locked_ = false;
+  bool is_monitor_power_on_ = false;
+  HPOWERNOTIFY power_notify_handle_ = nullptr;
 
   // TODO(benvanik): switch to bitmap.
   uint8_t key_down_map_[256] = {0};


### PR DESCRIPTION
Querying the screen saver is apparently black magic, so that's omitted.
Monitor physical power off doesn't seem to work either - only when
suspended by the system by power saving rules. Oh well.