### PR TITLE
Remove '-c dbg' from 'xtool sln' setup instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ ./xtool setup
 
 * Generate a Visual Studio solution; do this each time you change BUILD files:
 ```
-> xtool sln -c dbg
+> xtool sln
 ```
 * Open `.vs\xrtl.sln`, select a project, and press `F5`!
 


### PR DESCRIPTION
'xtool sln' now generates dbg, fastbuild, and opt and lets you pick between them in VS.