### PR TITLE
Making all GL operations happen on the queue thread.

### DIFF
--- a/third_party/swiftshader.BUILD
+++ b/third_party/swiftshader.BUILD
@@ -65,10 +65,11 @@ COMMON_COPTS = [
     "//conditions:default": [
         "-x",
         "c++",
-        "-Wno-sign-compare",
         "-Wno-inconsistent-missing-override",
-        "-Wno-unneeded-internal-declaration",
+        "-Wno-sign-compare",
         "-Wno-undefined-var-template",
+        "-Wno-unneeded-internal-declaration",
+        "-Wno-unused-lambda-capture",
         "-ffunction-sections",
         "-fdata-sections",
         "-fomit-frame-pointer",

--- a/xrtl/examples/triangle_example.cc
+++ b/xrtl/examples/triangle_example.cc
@@ -218,7 +218,7 @@ void main() {
     auto framebuffer_ready_fence = context_->CreateQueueFence();
     ref_ptr<ImageView> framebuffer_image_view;
     auto acquire_result = swap_chain_->AcquireNextImage(
-        std::chrono::milliseconds(100), framebuffer_ready_fence,
+        std::chrono::milliseconds(1000), framebuffer_ready_fence,
         &framebuffer_image_view);
     CHECK(acquire_result == SwapChain::AcquireResult::kSuccess ||
           acquire_result == SwapChain::AcquireResult::kResizeRequired);

--- a/xrtl/gfx/BUILD
+++ b/xrtl/gfx/BUILD
@@ -40,10 +40,10 @@ cc_library(
     deps = [
         ":command_encoder",
         ":framebuffer",
+        ":managed_object",
         ":render_pass",
         "//xrtl/base:logging",
         "//xrtl/base:macros",
-        "//xrtl/base:ref_ptr",
         "@com_google_absl//absl/types:span",
     ],
 )
@@ -70,7 +70,7 @@ cc_library(
     name = "command_fence",
     hdrs = ["command_fence.h"],
     deps = [
-        "//xrtl/base:ref_ptr",
+        ":managed_object",
     ],
 )
 
@@ -178,9 +178,9 @@ cc_library(
     hdrs = ["framebuffer.h"],
     deps = [
         ":image_view",
+        ":managed_object",
         ":render_pass",
         "//xrtl/base:geometry",
-        "//xrtl/base:ref_ptr",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/types:span",
     ],
@@ -201,7 +201,15 @@ cc_library(
     hdrs = ["image_view.h"],
     deps = [
         ":image",
+        ":managed_object",
         ":pixel_format",
+    ],
+)
+
+cc_library(
+    name = "managed_object",
+    hdrs = ["managed_object.h"],
+    deps = [
         "//xrtl/base:ref_ptr",
     ],
 )
@@ -213,9 +221,9 @@ cc_library(
     deps = [
         ":buffer",
         ":image",
+        ":managed_object",
         ":resource",
         "//xrtl/base:macros",
-        "//xrtl/base:ref_ptr",
     ],
 )
 
@@ -223,10 +231,10 @@ cc_library(
     name = "pipeline",
     hdrs = ["pipeline.h"],
     deps = [
+        ":managed_object",
         ":pipeline_layout",
         ":render_state",
         ":shader_module",
-        "//xrtl/base:ref_ptr",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -235,8 +243,8 @@ cc_library(
     name = "pipeline_layout",
     hdrs = ["pipeline_layout.h"],
     deps = [
+        ":managed_object",
         ":resource_set_layout",
-        "//xrtl/base:ref_ptr",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/types:span",
     ],
@@ -266,7 +274,7 @@ cc_library(
     name = "queue_fence",
     hdrs = ["queue_fence.h"],
     deps = [
-        "//xrtl/base:ref_ptr",
+        ":managed_object",
     ],
 )
 
@@ -275,10 +283,10 @@ cc_library(
     hdrs = ["render_pass.h"],
     deps = [
         ":image",
+        ":managed_object",
         ":pixel_format",
         ":render_state",
         "//xrtl/base:macros",
-        "//xrtl/base:ref_ptr",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/types:span",
     ],
@@ -298,7 +306,7 @@ cc_library(
     name = "resource",
     hdrs = ["resource.h"],
     deps = [
-        "//xrtl/base:ref_ptr",
+        ":managed_object",
     ],
 )
 
@@ -309,9 +317,9 @@ cc_library(
         ":buffer",
         ":image",
         ":image_view",
+        ":managed_object",
         ":resource_set_layout",
         ":sampler",
-        "//xrtl/base:ref_ptr",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/types:span",
     ],
@@ -321,8 +329,8 @@ cc_library(
     name = "resource_set_layout",
     hdrs = ["resource_set_layout.h"],
     deps = [
+        ":managed_object",
         ":render_pass",
-        "//xrtl/base:ref_ptr",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/types:span",
     ],
@@ -332,7 +340,7 @@ cc_library(
     name = "sampler",
     hdrs = ["sampler.h"],
     deps = [
-        "//xrtl/base:ref_ptr",
+        ":managed_object",
     ],
 )
 
@@ -340,7 +348,7 @@ cc_library(
     name = "shader_module",
     hdrs = ["shader_module.h"],
     deps = [
-        "//xrtl/base:ref_ptr",
+        ":managed_object",
     ],
 )
 
@@ -353,10 +361,10 @@ cc_library(
         ":framebuffer",
         ":image",
         ":image_view",
+        ":managed_object",
         ":pixel_format",
         ":queue_fence",
         "//xrtl/base:geometry",
-        "//xrtl/base:ref_ptr",
     ],
 )
 

--- a/xrtl/gfx/command_buffer.h
+++ b/xrtl/gfx/command_buffer.h
@@ -18,9 +18,9 @@
 #include <vector>
 
 #include "xrtl/base/macros.h"
-#include "xrtl/base/ref_ptr.h"
 #include "xrtl/gfx/command_encoder.h"
 #include "xrtl/gfx/framebuffer.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/render_pass.h"
 
 namespace xrtl {
@@ -69,9 +69,9 @@ XRTL_BITMASK(OperationQueueMask);
 //   // Submit the command buffer for execution.
 //   context->Submit(std::move(command_buffer), signal_fence);
 //
-class CommandBuffer : public RefObject<CommandBuffer> {
+class CommandBuffer : public ManagedObject {
  public:
-  virtual ~CommandBuffer();
+  ~CommandBuffer() override;
 
   // A bitmask indicating on which queue types this command buffer will execute
   // based on the commands that were encoded into it.

--- a/xrtl/gfx/command_fence.h
+++ b/xrtl/gfx/command_fence.h
@@ -15,7 +15,7 @@
 #ifndef XRTL_GFX_COMMAND_FENCE_H_
 #define XRTL_GFX_COMMAND_FENCE_H_
 
-#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/managed_object.h"
 
 namespace xrtl {
 namespace gfx {
@@ -27,10 +27,8 @@ namespace gfx {
 // These are device-side only and are only used to order the way commands
 // are processed within command buffers. They cannot be used for synchronization
 // with the CPU (use Context::WaitUntilQueuesIdle for that).
-class CommandFence : public RefObject<CommandFence> {
+class CommandFence : public ManagedObject {
  public:
-  virtual ~CommandFence() = default;
-
  protected:
   CommandFence() = default;
 };

--- a/xrtl/gfx/es3/BUILD
+++ b/xrtl/gfx/es3/BUILD
@@ -12,6 +12,8 @@ cc_library(
     deps = [
         ":es3_common",
         ":es3_platform_context",
+        ":es3_queue_object",
+        "//xrtl/base:tracing",
         "//xrtl/gfx:buffer",
         "//xrtl/gfx:memory_heap",
     ],
@@ -129,6 +131,7 @@ cc_library(
     hdrs = ["es3_framebuffer.h"],
     deps = [
         ":es3_common",
+        ":es3_queue_object",
         "//xrtl/gfx:framebuffer",
     ],
 )
@@ -142,6 +145,8 @@ cc_library(
         ":es3_image_view",
         ":es3_pixel_format",
         ":es3_platform_context",
+        ":es3_queue_object",
+        "//xrtl/base:tracing",
         "//xrtl/gfx:image",
         "//xrtl/gfx:memory_heap",
     ],
@@ -166,6 +171,7 @@ cc_library(
         ":es3_image",
         ":es3_pixel_format",
         ":es3_platform_context",
+        ":es3_queue_object",
         "//xrtl/base:math",
         "//xrtl/base:tracing",
         "//xrtl/gfx:memory_heap",
@@ -178,8 +184,8 @@ cc_library(
     hdrs = ["es3_pipeline.h"],
     deps = [
         ":es3_common",
-        ":es3_platform_context",
         ":es3_program",
+        ":es3_queue_object",
         "//xrtl/gfx:pipeline",
     ],
 )
@@ -276,9 +282,14 @@ cc_library(
         ":es3_common",
         ":es3_platform_context",
         ":es3_queue_fence",
+        ":es3_queue_object",
+        "//xrtl/base:intrusive_list",
+        "//xrtl/base:intrusive_pool",
         "//xrtl/base:tracing",
         "//xrtl/base/threading:event",
         "//xrtl/base/threading:thread",
+        "//xrtl/gfx:command_buffer",
+        "//xrtl/gfx:queue_fence",
         "//xrtl/gfx/util:memory_command_buffer",
         "//xrtl/gfx/util:memory_command_decoder",
         "@com_google_absl//absl/container:inlined_vector",
@@ -293,10 +304,21 @@ cc_library(
     deps = [
         ":es3_common",
         ":es3_platform_context",
+        ":es3_queue_object",
         "//xrtl/base:system_clock",
+        "//xrtl/base:tracing",
         "//xrtl/base/threading:event",
         "//xrtl/base/threading:thread",
         "//xrtl/gfx:queue_fence",
+    ],
+)
+
+cc_library(
+    name = "es3_queue_object",
+    hdrs = ["es3_queue_object.h"],
+    deps = [
+        ":es3_platform_context",
+        "//xrtl/base:ref_ptr",
     ],
 )
 
@@ -334,6 +356,7 @@ cc_library(
     deps = [
         ":es3_common",
         ":es3_platform_context",
+        ":es3_queue_object",
         "//xrtl/gfx:sampler",
     ],
 )
@@ -346,6 +369,7 @@ cc_library(
         ":es3_common",
         ":es3_platform_context",
         "//xrtl/base:debugging",
+        "//xrtl/base:ref_ptr",
         "//xrtl/base:tracing",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
@@ -359,7 +383,7 @@ cc_library(
     hdrs = ["es3_shader_module.h"],
     deps = [
         ":es3_common",
-        ":es3_platform_context",
+        ":es3_queue_object",
         ":es3_shader",
         "//xrtl/gfx:shader_module",
     ],

--- a/xrtl/gfx/es3/es3_buffer.h
+++ b/xrtl/gfx/es3/es3_buffer.h
@@ -19,17 +19,16 @@
 
 #include "xrtl/gfx/buffer.h"
 #include "xrtl/gfx/es3/es3_common.h"
-#include "xrtl/gfx/es3/es3_platform_context.h"
+#include "xrtl/gfx/es3/es3_queue_object.h"
 
 namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-class ES3Buffer : public Buffer {
+class ES3Buffer : public Buffer, public ES3QueueObject {
  public:
-  ES3Buffer(ref_ptr<ES3PlatformContext> platform_context,
-            ref_ptr<MemoryHeap> memory_heap, size_t allocation_size,
-            Usage usage_mask);
+  ES3Buffer(ES3ObjectLifetimeQueue* queue, ref_ptr<MemoryHeap> memory_heap,
+            size_t allocation_size, Usage usage_mask);
   ~ES3Buffer() override;
 
   ref_ptr<MemoryHeap> memory_heap() const override;
@@ -46,14 +45,16 @@ class ES3Buffer : public Buffer {
 
   void FlushMappedMemory(size_t byte_offset, size_t byte_length) override;
 
-  void Release() override;
-
  private:
+  void Release() override;
+  bool AllocateOnQueue() override;
+  void DeallocateOnQueue() override;
+
   bool MapMemory(MemoryAccess memory_access, size_t* byte_offset,
                  size_t* byte_length, void** out_data) override;
   void UnmapMemory(size_t byte_offset, size_t byte_length, void* data) override;
 
-  ref_ptr<ES3PlatformContext> platform_context_;
+  ES3ObjectLifetimeQueue* queue_;
   ref_ptr<MemoryHeap> memory_heap_;
 
   GLenum target_ = GL_COPY_READ_BUFFER;

--- a/xrtl/gfx/es3/es3_common.h
+++ b/xrtl/gfx/es3/es3_common.h
@@ -50,6 +50,13 @@
 #define DCHECK_CONTEXT_IS_CURRENT(context)
 #endif  // DEBUG_GL
 
+// An attribute that can be placed on methods to indicate that a GL context must
+// be current before the method is called.
+// This is for now used only for readability.
+// TODO(benvanik): abuse absl threading annotations and Mutex to get static
+//                 verification of this?
+#define XRTL_REQUIRES_GL_CONTEXT
+
 namespace xrtl {
 namespace gfx {
 namespace es3 {

--- a/xrtl/gfx/es3/es3_image.h
+++ b/xrtl/gfx/es3/es3_image.h
@@ -19,20 +19,20 @@
 
 #include "xrtl/gfx/es3/es3_common.h"
 #include "xrtl/gfx/es3/es3_pixel_format.h"
-#include "xrtl/gfx/es3/es3_platform_context.h"
+#include "xrtl/gfx/es3/es3_queue_object.h"
 #include "xrtl/gfx/image.h"
 
 namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-class ES3Image : public Image {
+class ES3Image : public Image, public ES3QueueObject {
  public:
   static size_t ComputeAllocationSize(const Image::CreateParams& create_params);
 
-  ES3Image(ref_ptr<ES3PlatformContext> platform_context,
-           ref_ptr<MemoryHeap> memory_heap, ES3TextureParams texture_params,
-           size_t allocation_size, CreateParams create_params);
+  ES3Image(ES3ObjectLifetimeQueue* queue, ref_ptr<MemoryHeap> memory_heap,
+           ES3TextureParams texture_params, size_t allocation_size,
+           CreateParams create_params);
   ~ES3Image() override;
 
   ref_ptr<MemoryHeap> memory_heap() const override;
@@ -51,10 +51,12 @@ class ES3Image : public Image {
   bool WriteData(LayerRange target_range, const void* data,
                  size_t data_length) override;
 
-  void Release() override;
-
  private:
-  ref_ptr<ES3PlatformContext> platform_context_;
+  void Release() override;
+  bool AllocateOnQueue() override;
+  void DeallocateOnQueue() override;
+
+  ES3ObjectLifetimeQueue* queue_;
   ref_ptr<MemoryHeap> memory_heap_;
   ES3TextureParams texture_params_;
 

--- a/xrtl/gfx/es3/es3_memory_heap.h
+++ b/xrtl/gfx/es3/es3_memory_heap.h
@@ -18,17 +18,17 @@
 #include <mutex>
 
 #include "xrtl/gfx/es3/es3_common.h"
-#include "xrtl/gfx/es3/es3_platform_context.h"
+#include "xrtl/gfx/es3/es3_queue_object.h"
 #include "xrtl/gfx/memory_heap.h"
 
 namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-class ES3MemoryHeap : public MemoryHeap {
+class ES3MemoryHeap : public MemoryHeap, public ES3QueueObject {
  public:
-  ES3MemoryHeap(ref_ptr<ES3PlatformContext> platform_context,
-                MemoryType memory_type_mask, size_t heap_size);
+  ES3MemoryHeap(ES3ObjectLifetimeQueue* queue, MemoryType memory_type_mask,
+                size_t heap_size);
   ~ES3MemoryHeap() override;
 
   size_t allocation_alignment() const override { return allocation_alignment_; }
@@ -42,10 +42,14 @@ class ES3MemoryHeap : public MemoryHeap {
                                  ref_ptr<Image>* out_image) override;
 
  private:
+  void Release() override;
+  bool AllocateOnQueue() override;
+  void DeallocateOnQueue() override;
+
   void ReleaseBuffer(Buffer* buffer) override;
   void ReleaseImage(Image* image) override;
 
-  ref_ptr<ES3PlatformContext> platform_context_;
+  ES3ObjectLifetimeQueue* queue_;
 
   size_t allocation_alignment_ = 0;
 

--- a/xrtl/gfx/es3/es3_pipeline.h
+++ b/xrtl/gfx/es3/es3_pipeline.h
@@ -19,17 +19,19 @@
 #include <utility>
 
 #include "xrtl/gfx/es3/es3_common.h"
-#include "xrtl/gfx/es3/es3_platform_context.h"
 #include "xrtl/gfx/es3/es3_program.h"
+#include "xrtl/gfx/es3/es3_queue_object.h"
 #include "xrtl/gfx/pipeline.h"
 
 namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-class ES3ComputePipeline : public ComputePipeline {
+class ES3Queue;
+
+class ES3ComputePipeline : public ComputePipeline, public ES3QueueObject {
  public:
-  ES3ComputePipeline(ref_ptr<ES3PlatformContext> platform_context,
+  ES3ComputePipeline(ES3ObjectLifetimeQueue* queue,
                      ref_ptr<PipelineLayout> pipeline_layout,
                      ref_ptr<ShaderModule> shader_module,
                      absl::string_view entry_point,
@@ -39,13 +41,17 @@ class ES3ComputePipeline : public ComputePipeline {
   ref_ptr<ES3Program> program() const { return program_; }
 
  private:
-  ref_ptr<ES3PlatformContext> platform_context_;
+  void Release() override;
+  bool AllocateOnQueue() override;
+  void DeallocateOnQueue() override;
+
+  ES3ObjectLifetimeQueue* queue_;
   ref_ptr<ES3Program> program_;
 };
 
-class ES3RenderPipeline : public RenderPipeline {
+class ES3RenderPipeline : public RenderPipeline, public ES3QueueObject {
  public:
-  ES3RenderPipeline(ref_ptr<ES3PlatformContext> platform_context,
+  ES3RenderPipeline(ES3ObjectLifetimeQueue* queue,
                     ref_ptr<PipelineLayout> pipeline_layout,
                     ref_ptr<RenderPass> render_pass, int render_subpass,
                     RenderState render_state,
@@ -56,7 +62,11 @@ class ES3RenderPipeline : public RenderPipeline {
   ref_ptr<ES3Program> program() const { return program_; }
 
  private:
-  ref_ptr<ES3PlatformContext> platform_context_;
+  void Release() override;
+  bool AllocateOnQueue() override;
+  void DeallocateOnQueue() override;
+
+  ES3ObjectLifetimeQueue* queue_;
   ref_ptr<ES3Program> program_;
 };
 

--- a/xrtl/gfx/es3/es3_platform_context.h
+++ b/xrtl/gfx/es3/es3_platform_context.h
@@ -185,31 +185,11 @@ class ES3PlatformContext : public RefObject<ES3PlatformContext> {
     return Create(nullptr, nullptr, {});
   }
 
-  // Acquires a thread-locked context that is in a share-group with the given
-  // context. Future calls to AcquireThreadContext from the same thread will
-  // return the same context. It's safe to use this context with a ThreadLock
-  // and keep it current on the calling thread. Avoid using thread-locked
-  // contexts with ExclusiveLock as it can cause undefined behavior.
-  //
-  // The context will be retained for the life of the calling thread or until
-  // ReleaseThreadContext is called.
-  //
-  // Returns the thread-locked context, if one could be created. If the given
-  // context happens to already be the thread-locked context for the current
-  // thread that will be returned.
-  static ref_ptr<ES3PlatformContext> AcquireThreadContext(
-      ref_ptr<ES3PlatformContext> existing_context);
-
-  // Releases a thread-locked context for the current thread, if any exists.
-  // Calling AcquireThreadContext will recreate a new context for the thread.
-  static void ReleaseThreadContext();
-
-  // Acquires a context to use for short operations.
-  // If a context is already made current on the calling thread this will return
-  // that context. Otherwise, this will return a thread-locked context as if
-  // AcquireThreadContext had been used.
-  static ThreadLock LockTransientContext(
-      ref_ptr<ES3PlatformContext> existing_context);
+  // CHECKs that any GL context is locked on the calling thread and available
+  // for use.
+  static void CheckHasContextLock();
+  // Returns true if any GL context is locked on the calling thread.
+  static bool HasContextLock();
 
   virtual ~ES3PlatformContext();
 

--- a/xrtl/gfx/es3/es3_queue.cc
+++ b/xrtl/gfx/es3/es3_queue.cc
@@ -14,7 +14,11 @@
 
 #include "xrtl/gfx/es3/es3_queue.h"
 
+#include <memory>
+
 #include "xrtl/base/tracing.h"
+#include "xrtl/gfx/es3/es3_command_buffer.h"
+#include "xrtl/gfx/es3/es3_queue_fence.h"
 #include "xrtl/gfx/util/memory_command_buffer.h"
 #include "xrtl/gfx/util/memory_command_decoder.h"
 
@@ -26,6 +30,8 @@ ES3Queue::ES3Queue(Type queue_type,
                    ref_ptr<ES3PlatformContext> shared_platform_context)
     : shared_platform_context_(std::move(shared_platform_context)),
       queue_type_(queue_type) {
+  WTF_SCOPE0("ES3Queue#ctor");
+
   queue_work_pending_event_ = Event::CreateAutoResetEvent(false);
   queue_work_completed_event_ = Event::CreateAutoResetEvent(false);
 
@@ -36,6 +42,8 @@ ES3Queue::ES3Queue(Type queue_type,
 }
 
 ES3Queue::~ES3Queue() {
+  WTF_SCOPE0("ES3Queue#dtor");
+
   // Join with queue thread.
   if (queue_thread_) {
     {
@@ -54,10 +62,23 @@ void ES3Queue::EnqueueCommandBuffers(
     ref_ptr<Event> signal_handle) {
   // Presentation queues cannot handle command buffers.
   DCHECK(queue_type_ != Type::kPresentation);
-  std::lock_guard<std::mutex> lock(queue_mutex_);
-  DCHECK(queue_running_);
-  queue_.emplace(wait_queue_fences, command_buffers, signal_queue_fences,
-                 signal_handle);
+  QueueEntry* queue_entry = nullptr;
+  {
+    std::lock_guard<std::recursive_mutex> pool_lock(queue_entry_pool_mutex_);
+    queue_entry = queue_entry_pool_.Allocate();
+  }
+  queue_entry->wait_queue_fences = {wait_queue_fences.begin(),
+                                    wait_queue_fences.end()};
+  queue_entry->command_buffers = {command_buffers.begin(),
+                                  command_buffers.end()};
+  queue_entry->signal_queue_fences = {signal_queue_fences.begin(),
+                                      signal_queue_fences.end()};
+  queue_entry->signal_handle = std::move(signal_handle);
+  {
+    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    DCHECK(queue_running_);
+    queue_.push_back(queue_entry);
+  }
   queue_work_pending_event_->Set();
 }
 
@@ -67,11 +88,75 @@ void ES3Queue::EnqueueCallback(
     std::function<void()> callback,
     absl::Span<const ref_ptr<QueueFence>> signal_queue_fences,
     ref_ptr<Event> signal_handle) {
-  std::lock_guard<std::mutex> lock(queue_mutex_);
-  DCHECK(queue_running_);
-  queue_.emplace(std::move(exclusive_context), wait_queue_fences,
-                 std::move(callback), signal_queue_fences, signal_handle);
+  QueueEntry* queue_entry = nullptr;
+  {
+    std::lock_guard<std::recursive_mutex> pool_lock(queue_entry_pool_mutex_);
+    queue_entry = queue_entry_pool_.Allocate();
+  }
+  queue_entry->exclusive_context = std::move(exclusive_context);
+  queue_entry->wait_queue_fences = {wait_queue_fences.begin(),
+                                    wait_queue_fences.end()};
+  queue_entry->callback = std::move(callback);
+  queue_entry->signal_queue_fences = {signal_queue_fences.begin(),
+                                      signal_queue_fences.end()};
+  queue_entry->signal_handle = std::move(signal_handle);
+  {
+    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    DCHECK(queue_running_);
+    queue_.push_back(queue_entry);
+  }
   queue_work_pending_event_->Set();
+}
+
+void ES3Queue::EnqueueObjectCallback(
+    ES3QueueObject* obj, ObjectReleaseCallback release_callback,
+    std::function<void()> callback,
+    ref_ptr<ES3PlatformContext> exclusive_context) {
+  QueueEntry* queue_entry = nullptr;
+  {
+    std::lock_guard<std::recursive_mutex> pool_lock(queue_entry_pool_mutex_);
+    queue_entry = queue_entry_pool_.Allocate();
+  }
+  queue_entry->exclusive_context = std::move(exclusive_context);
+  auto callback_baton = MoveToLambda(callback);
+  queue_entry->callback = [obj, release_callback, callback_baton]() {
+    callback_baton.value();
+    release_callback(obj);
+  };
+  {
+    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    // NOTE: we allow queuing even if the queue is shutting down as we need to
+    // ensure object operations still run.
+    queue_.push_back(queue_entry);
+  }
+  queue_work_pending_event_->Set();
+}
+
+bool ES3Queue::SyncObjectCallback(
+    ES3QueueObject* obj, std::function<bool()> callback,
+    ref_ptr<ES3PlatformContext> exclusive_context) {
+  WTF_SCOPE0("ES3Queue#SyncObjectCallback");
+  auto signal_handle = Event::CreateFence();
+  QueueEntry* queue_entry = nullptr;
+  {
+    std::lock_guard<std::recursive_mutex> pool_lock(queue_entry_pool_mutex_);
+    queue_entry = queue_entry_pool_.Allocate();
+  }
+  queue_entry->exclusive_context = std::move(exclusive_context);
+  auto callback_baton = MoveToLambda(callback);
+  bool result = false;
+  queue_entry->callback = [callback_baton, &result]() {
+    result = callback_baton.value();
+  };
+  queue_entry->signal_handle = signal_handle;
+  {
+    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    // NOTE: we allow queuing even if the queue is shutting down as we need to
+    // ensure object operations still run.
+    queue_.push_back(queue_entry);
+  }
+  queue_work_pending_event_->Set();
+  return Thread::Wait(signal_handle) == Thread::WaitResult::kSuccess && result;
 }
 
 bool ES3Queue::WaitUntilIdle() {
@@ -85,7 +170,7 @@ bool ES3Queue::WaitUntilIdle() {
     }
     Thread::Wait(queue_work_completed_event_);
   }
-  return true;  // Unreachable
+  return true;  // Unreachable (here to make GCC happy).
 }
 
 void ES3Queue::QueueThreadMain(void* param) {
@@ -101,8 +186,9 @@ void ES3Queue::RunQueue() {
   // predictable.
   ref_ptr<ES3PlatformContext> queue_context;
   if (queue_type_ != Type::kPresentation) {
-    queue_context =
-        ES3PlatformContext::AcquireThreadContext(shared_platform_context_);
+    WTF_SCOPE0("ES3Queue#RunQueue:context_init");
+    // TODO(benvanik): allocate a dedicated queue context on transfer queues.
+    queue_context = shared_platform_context_;
     if (!queue_context) {
       LOG(FATAL) << "Unable to allocate a queue platform context";
       return;
@@ -113,41 +199,59 @@ void ES3Queue::RunQueue() {
   // makes GL calls. We'll allocate it on demand.
   ref_ptr<ES3CommandBuffer> implementation_command_buffer;
 
+  // Used to ensure we release our dequeued queue entry when done with it.
+  auto release_entry = [this](QueueEntry* queue_entry) {
+    std::lock_guard<std::recursive_mutex> lock(queue_entry_pool_mutex_);
+    queue_entry_pool_.Release(queue_entry);
+  };
+
   while (true) {
-    QueueEntry queue_entry;
+    std::unique_ptr<QueueEntry, decltype(release_entry)> queue_entry{
+        nullptr, release_entry};
+
     {
       std::lock_guard<std::mutex> lock(queue_mutex_);
-      if (!queue_running_) {
-        // Queue is shutting down; exit thread.
-        break;
-      }
 
-      // Attempt to dequeue a command buffer set.
+      // Attempt to dequeue an entry.
       if (!queue_.empty()) {
-        queue_entry = std::move(queue_.front());
-        queue_.pop();
+        queue_entry.reset(queue_.front());
+        queue_.pop_front();
         queue_executing_ = true;
       } else {
         // Signal that there was no work available.
         queue_work_completed_event_->Set();
+        if (!queue_running_) {
+          // Queue shutting down and nothing queued - exit now.
+          break;
+        }
+      }
+
+      if (!queue_running_) {
+        // Queue is shutting down; ignore non-critical entries.
+        if (queue_entry->discardable) {
+          queue_executing_ = false;
+          continue;
+        }
       }
     }
 
     // If there was no work pending wait for more work.
-    if (!queue_executing_) {
+    if (!queue_entry) {
       Thread::Wait(queue_work_pending_event_);
       continue;
     }
 
+    WTF_SCOPE0("ES3Queue#RunQueue:entry");
+
     ES3PlatformContext::ExclusiveLock exclusive_lock;
     ES3PlatformContext::ThreadLock thread_lock;
-    if (queue_entry.exclusive_context) {
+    if (queue_entry->exclusive_context) {
       // Exclusive lock on the request-provided context.
-      exclusive_lock.reset(queue_entry.exclusive_context);
+      exclusive_lock.reset(queue_entry->exclusive_context);
       if (!exclusive_lock.is_held()) {
         LOG(FATAL) << "Unable to make current the provided platform context";
       }
-    } else {
+    } else if (queue_context) {
       // Use the queue context.
       DCHECK(queue_context);
       thread_lock.reset(queue_context);
@@ -157,48 +261,53 @@ void ES3Queue::RunQueue() {
     }
 
     // Wait on queue fences.
-    for (const auto& queue_fence : queue_entry.wait_queue_fences) {
+    for (const auto& queue_fence : queue_entry->wait_queue_fences) {
       queue_fence.As<ES3QueueFence>()->WaitOnServer(
           std::chrono::nanoseconds::max());
     }
 
     // Execute command buffers.
-    if (!queue_entry.command_buffers.empty()) {
+    if (!queue_entry->command_buffers.empty()) {
       if (!implementation_command_buffer) {
         implementation_command_buffer = make_ref<ES3CommandBuffer>();
       }
-      ExecuteCommandBuffers(queue_entry.command_buffers,
-                            implementation_command_buffer);
+      ExecuteCommandBuffers(queue_entry->command_buffers,
+                            implementation_command_buffer.get());
     }
 
     // Execute callback.
-    if (queue_entry.callback) {
-      queue_entry.callback();
+    if (queue_entry->callback) {
+      queue_entry->callback();
     }
 
     // Signal queue fences.
-    for (const auto& queue_fence : queue_entry.signal_queue_fences) {
-      queue_fence.As<ES3QueueFence>()->Signal();
+    for (const auto& queue_fence : queue_entry->signal_queue_fences) {
+      queue_fence.As<ES3QueueFence>()->SignalServer();
     }
 
     // Signal CPU event.
-    if (queue_entry.signal_handle) {
-      queue_entry.signal_handle->Set();
+    if (queue_entry->signal_handle) {
+      queue_entry->signal_handle->Set();
     }
 
-    std::lock_guard<std::mutex> lock(queue_mutex_);
     queue_executing_ = false;
+    queue_entry.reset();
   }
 
   queue_work_completed_event_->Set();
   implementation_command_buffer.reset();
-  queue_context.reset();
-  ES3PlatformContext::ReleaseThreadContext();
+  if (queue_context) {
+    queue_context->ClearCurrent();
+    queue_context.reset();
+  }
 }
 
 void ES3Queue::ExecuteCommandBuffers(
     absl::Span<const ref_ptr<CommandBuffer>> command_buffers,
-    ref_ptr<ES3CommandBuffer> implementation_command_buffer) {
+    ES3CommandBuffer* implementation_command_buffer) {
+  WTF_SCOPE0("ES3Queue#ExecuteCommandBuffers");
+  ES3PlatformContext::CheckHasContextLock();
+
   for (const auto& command_buffer : command_buffers) {
     // Reset GL state.
     implementation_command_buffer->PrepareState();
@@ -209,7 +318,7 @@ void ES3Queue::ExecuteCommandBuffers(
 
     // Execute the command buffer against our native GL implementation.
     util::MemoryCommandDecoder::Decode(&command_reader,
-                                       implementation_command_buffer.get());
+                                       implementation_command_buffer);
 
     // Reset our execution command buffer to clear all state.
     // This ensures that the next time we start using it the state is clean

--- a/xrtl/gfx/es3/es3_queue.h
+++ b/xrtl/gfx/es3/es3_queue.h
@@ -15,28 +15,34 @@
 #ifndef XRTL_GFX_ES3_ES3_QUEUE_H_
 #define XRTL_GFX_ES3_ES3_QUEUE_H_
 
+#include <atomic>
 #include <functional>
 #include <queue>
 #include <utility>
 
 #include "absl/container/inlined_vector.h"
 #include "absl/types/span.h"
+#include "xrtl/base/intrusive_list.h"
+#include "xrtl/base/intrusive_pool.h"
 #include "xrtl/base/threading/event.h"
 #include "xrtl/base/threading/thread.h"
-#include "xrtl/gfx/es3/es3_command_buffer.h"
+#include "xrtl/gfx/command_buffer.h"
 #include "xrtl/gfx/es3/es3_common.h"
 #include "xrtl/gfx/es3/es3_platform_context.h"
-#include "xrtl/gfx/es3/es3_queue_fence.h"
+#include "xrtl/gfx/es3/es3_queue_object.h"
+#include "xrtl/gfx/queue_fence.h"
 
 namespace xrtl {
 namespace gfx {
 namespace es3 {
 
+class ES3CommandBuffer;
+
 // A command queue for use by ES3Context.
 // Each queue instance maintains its own thread and dedicated GL platform
 // context that it uses for submission. The queue processes enqueued command
 // buffers and callbacks in FIFO order.
-class ES3Queue {
+class ES3Queue : public ES3ObjectLifetimeQueue {
  public:
   enum class Type {
     // Queue is used for command buffer submission.
@@ -48,7 +54,7 @@ class ES3Queue {
 
   ES3Queue(Type queue_type,
            ref_ptr<ES3PlatformContext> shared_platform_context);
-  ~ES3Queue();
+  ~ES3Queue() override;
 
   // Enqueues a set of command buffers to be executed from the queue.
   void EnqueueCommandBuffers(
@@ -71,56 +77,73 @@ class ES3Queue {
   bool WaitUntilIdle();
 
  private:
+  // An entry containing the required information to sequence and execute
+  // a queue request.
+  struct QueueEntry : public IntrusiveLinkBase<void> {
+    // Whether the queue entry can be safetly discarded during shutdown.
+    bool discardable = false;
+
+    // Context under which the command buffers/callback should run.
+    // If omitted the queue context will be used.
+    ref_ptr<ES3PlatformContext> exclusive_context;
+
+    // Fences that must signal before the entry is allowed to process.
+    absl::InlinedVector<ref_ptr<QueueFence>, 4> wait_queue_fences;
+
+    // Command buffers, callback, or object operation to perform.
+    absl::InlinedVector<ref_ptr<CommandBuffer>, 4> command_buffers;
+    std::function<void()> callback;
+
+    // Fences that will be signaled after the entry has processed.
+    absl::InlinedVector<ref_ptr<QueueFence>, 4> signal_queue_fences;
+    // An event that will be set after the entry has processed.
+    ref_ptr<Event> signal_handle;
+  };
+
+  void EnqueueObjectCallback(
+      ES3QueueObject* obj, ObjectReleaseCallback release_callback,
+      std::function<void()> callback,
+      ref_ptr<ES3PlatformContext> exclusive_context) override;
+  bool SyncObjectCallback(
+      ES3QueueObject* obj, std::function<bool()> callback,
+      ref_ptr<ES3PlatformContext> exclusive_context) override;
+
   static void QueueThreadMain(void* param);
   void RunQueue();
+
+  // Executes a list of command buffers against the underlying GL context.
   void ExecuteCommandBuffers(
       absl::Span<const ref_ptr<CommandBuffer>> command_buffers,
-      ref_ptr<ES3CommandBuffer> implementation_command_buffer);
+      ES3CommandBuffer* implementation_command_buffer) XRTL_REQUIRES_GL_CONTEXT;
 
   // Base platform context used by the parent ES3Context.
   ref_ptr<ES3PlatformContext> shared_platform_context_;
 
   Type queue_type_;
 
+  // Thread running the queue. Depending on the queue type the thread may own
+  // its own platform context for its lifetime.
   ref_ptr<Thread> queue_thread_;
+  // Auto-reset event signaled when a new entry is enqueued.
   ref_ptr<Event> queue_work_pending_event_;
+  // Auto-reset event signaled when an entry has been completed.
   ref_ptr<Event> queue_work_completed_event_;
 
+  // Mutex that must be used to guard all queue structures.
   std::mutex queue_mutex_;
+  // True so long as the queue is running. After the queue has stopped future
+  // enqueued requests may not execute.
   bool queue_running_ = true;
-  bool queue_executing_ = false;
-
-  struct QueueEntry {
-    ref_ptr<ES3PlatformContext> exclusive_context;
-    absl::InlinedVector<ref_ptr<QueueFence>, 4> wait_queue_fences;
-    absl::InlinedVector<ref_ptr<CommandBuffer>, 4> command_buffers;
-    std::function<void()> callback;
-    absl::InlinedVector<ref_ptr<QueueFence>, 4> signal_queue_fences;
-    ref_ptr<Event> signal_handle;
-    QueueEntry() = default;
-    QueueEntry(absl::Span<const ref_ptr<QueueFence>> wait_queue_fences,
-               absl::Span<const ref_ptr<CommandBuffer>> command_buffers,
-               absl::Span<const ref_ptr<QueueFence>> signal_queue_fences,
-               ref_ptr<Event> signal_handle)
-        : wait_queue_fences(wait_queue_fences.begin(), wait_queue_fences.end()),
-          command_buffers(command_buffers.begin(), command_buffers.end()),
-          signal_queue_fences(signal_queue_fences.begin(),
-                              signal_queue_fences.end()),
-          signal_handle(std::move(signal_handle)) {}
-    QueueEntry(ref_ptr<ES3PlatformContext> exclusive_context,
-               absl::Span<const ref_ptr<QueueFence>> wait_queue_fences,
-               std::function<void()> callback,
-               absl::Span<const ref_ptr<QueueFence>> signal_queue_fences,
-               ref_ptr<Event> signal_handle)
-        : exclusive_context(std::move(exclusive_context)),
-          wait_queue_fences(wait_queue_fences.begin(), wait_queue_fences.end()),
-          callback(std::move(callback)),
-          signal_queue_fences(signal_queue_fences.begin(),
-                              signal_queue_fences.end()),
-          signal_handle(std::move(signal_handle)) {}
-  };
-
-  std::queue<QueueEntry> queue_;
+  // True if the queue is actively executing an entry.
+  std::atomic<bool> queue_executing_{false};
+  // All currently pending entries.
+  IntrusiveList<QueueEntry> queue_;
+  // A mutex exclusively for guarding the queue entry pool.
+  // We do this so that we don't block the queue while managing entries (such as
+  // running down destructors/etc).
+  std::recursive_mutex queue_entry_pool_mutex_;
+  // A pool of entries to prevent reallocation.
+  IntrusivePool<QueueEntry> queue_entry_pool_{16, 32};
 };
 
 }  // namespace es3

--- a/xrtl/gfx/es3/es3_queue_fence.cc
+++ b/xrtl/gfx/es3/es3_queue_fence.cc
@@ -18,54 +18,119 @@
 
 #include "xrtl/base/system_clock.h"
 #include "xrtl/base/threading/thread.h"
+#include "xrtl/base/tracing.h"
+#include "xrtl/gfx/es3/es3_platform_context.h"
 
 namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-ES3QueueFence::ES3QueueFence(ref_ptr<ES3PlatformContext> platform_context)
-    : platform_context_(std::move(platform_context)) {
-  fence_id_ = 0;
+ES3QueueFence::ES3QueueFence(ES3ObjectLifetimeQueue* queue) : queue_(queue) {
   issued_fence_ = Event::CreateFence();
+  queue_->EnqueueObjectAllocation(this);
 }
 
-ES3QueueFence::~ES3QueueFence() {
+ES3QueueFence::~ES3QueueFence() = default;
+
+void ES3QueueFence::Release() { queue_->EnqueueObjectDeallocation(this); }
+
+bool ES3QueueFence::AllocateOnQueue() { return true; }
+
+void ES3QueueFence::DeallocateOnQueue() {
+  ES3PlatformContext::CheckHasContextLock();
   GLsync fence_id = 0;
   {
     std::lock_guard<std::mutex> lock_guard(mutex_);
-    std::swap(fence_id, fence_id_);
+    fence_id = fence_id_;
+    fence_id_ = nullptr;
   }
   if (fence_id) {
-    auto context_lock =
-        ES3PlatformContext::LockTransientContext(platform_context_);
     glDeleteSync(fence_id);
   }
 }
 
-bool ES3QueueFence::IsSignaled() {
-  std::lock_guard<std::mutex> lock_guard(mutex_);
-  if (!fence_id_) {
-    // Have not yet got a fence allocated.
-    return false;
+ES3QueueFence::FenceState ES3QueueFence::QueryState() {
+  {
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    if (is_signaled_) {
+      return FenceState::kSignaled;
+    } else if (!is_issued_ || !fence_id_) {
+      // Have not yet got a fence allocated.
+      return FenceState::kUnsignaled;
+    }
   }
-  auto context_lock =
-      ES3PlatformContext::LockTransientContext(platform_context_);
-  GLint value = 0;
-  GLsizei value_count = 1;
-  glGetSynciv(fence_id_, GL_SYNC_STATUS, sizeof(value), &value_count, &value);
-  return value == GL_SIGNALED;
+
+  // TODO(benvanik): optimize this by keeping a list of pending fences on the
+  //                 queue and querying periodically. This marshaling kills our
+  //                 'polls are fast' rule.
+  WTF_SCOPE0("ES3QueueFence#QueryState:sync");
+  FenceState fence_state = FenceState::kDeviceLost;
+  queue_->EnqueueObjectCallbackAndWait(this, [this, &fence_state]() {
+    WTF_SCOPE0("ES3QueueFence#QueryState:queue");
+    ES3PlatformContext::CheckHasContextLock();
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    if (is_signaled_) {
+      // We've been signaled since we were requested.
+      fence_state = FenceState::kSignaled;
+      return true;
+    }
+    GLint value = 0;
+    GLsizei value_count = 1;
+    glGetSynciv(fence_id_, GL_SYNC_STATUS, sizeof(value), &value_count, &value);
+    fence_state =
+        value == GL_SIGNALED ? FenceState::kSignaled : FenceState::kUnsignaled;
+    if (fence_state == FenceState::kSignaled) {
+      // Cache signaled state for future queries.
+      is_signaled_ = true;
+    }
+    return true;
+  });
+  return fence_state;
 }
 
 void ES3QueueFence::Signal() {
-  // Issue the fence into the GL command stream.
-  {
-    auto context_lock =
-        ES3PlatformContext::LockTransientContext(platform_context_);
-    std::lock_guard<std::mutex> lock_guard(mutex_);
-    DCHECK(!fence_id_);
-    fence_id_ = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-    DCHECK(fence_id_);
+  if (ES3PlatformContext::HasContextLock()) {
+    SignalServer();
+  } else {
+    SignalClient();
   }
+}
+
+void ES3QueueFence::SignalClient() {
+  WTF_SCOPE0("ES3QueueFence#SignalClient");
+  {
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    if (is_signaled_) {
+      // Already signaled - don't redundantly signal.
+      return;
+    }
+    // NOTE: we allow signaling here even if we've already issued the server
+    // fence as the client is overriding the previous server signal and
+    // indicating they want the fence to complete immediately.
+    is_issued_ = true;
+    is_signaled_ = true;
+  }
+
+  // Allow those waiting on the fence to be created to continue.
+  // They'll immediately see the is_signaled_ flag and complete their wait.
+  issued_fence_->Set();
+}
+
+void ES3QueueFence::SignalServer() {
+  WTF_SCOPE0("ES3QueueFence#SignalServer");
+  {
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    if (is_issued_ || is_signaled_) {
+      // Already issued or signaled - don't redundantly signal.
+      return;
+    }
+    is_issued_ = true;
+  }
+
+  // Insert into the command queue.
+  DCHECK(!fence_id_);
+  fence_id_ = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+  DCHECK(fence_id_);
 
   // Allow those waiting on the fence to be created to continue.
   issued_fence_->Set();
@@ -73,6 +138,10 @@ void ES3QueueFence::Signal() {
 
 ES3QueueFence::WaitResult ES3QueueFence::Wait(
     std::chrono::nanoseconds timeout_nanos) {
+  WTF_SCOPE0("ES3QueueFence#Wait");
+
+  // Wait for the fence to be issued as we need a fence ID to pass to GL.
+  // If the fence has already been signaled this will return immediately.
   std::chrono::nanoseconds adjusted_timeout_nanos = timeout_nanos;
   GLsync fence_id = 0;
   WaitResult wait_result = WaitForIssue(&adjusted_timeout_nanos, &fence_id);
@@ -80,24 +149,79 @@ ES3QueueFence::WaitResult ES3QueueFence::Wait(
     return wait_result;
   }
 
-  // Wait on the GPU to signal the fence.
-  auto context_lock =
-      ES3PlatformContext::LockTransientContext(platform_context_);
-  GLenum wait_return = glClientWaitSync(fence_id, GL_SYNC_FLUSH_COMMANDS_BIT,
-                                        timeout_nanos.count());
-  switch (wait_return) {
-    case GL_CONDITION_SATISFIED:
-    case GL_ALREADY_SIGNALED:
+  {
+    // Check if we were signaled already.
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    if (is_signaled_) {
       return WaitResult::kSuccess;
-    case GL_TIMEOUT_EXPIRED:
-      return WaitResult::kTimeout;
-    case GL_WAIT_FAILED:
-    default:
-      return WaitResult::kDeviceLost;
+    }
   }
+  DCHECK(fence_id);
+
+  // Marshal to the queue to perform the wait. We never promised this would be
+  // fast, and the hottest use of queue fences is command buffer ordering and
+  // that uses WaitOnServer instead.
+  std::chrono::microseconds start_time_micros =
+      SystemClock::default_clock()->now_micros();
+  wait_result = WaitResult::kDeviceLost;
+  queue_->EnqueueObjectCallbackAndWait(this, [this, &wait_result, fence_id,
+                                              adjusted_timeout_nanos,
+                                              start_time_micros]() {
+    ES3PlatformContext::CheckHasContextLock();
+
+    // Account in the timeout for how long it took to marshal across to the
+    // GL queue. If the queue is busy this may actually be a decent chunk
+    // of time.
+    std::chrono::nanoseconds elapsed_time_nanos =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            SystemClock::default_clock()->now_micros() - start_time_micros);
+    if (elapsed_time_nanos > adjusted_timeout_nanos) {
+      // Timed out before we even got to the wait. Perform a non-blocking
+      // query instead so we don't block at any longer.
+      GLint value = 0;
+      GLsizei value_count = 1;
+      glGetSynciv(fence_id, GL_SYNC_STATUS, sizeof(value), &value_count,
+                  &value);
+      wait_result =
+          value == GL_SIGNALED ? WaitResult::kSuccess : WaitResult::kTimeout;
+      return true;
+    }
+    std::chrono::nanoseconds readjusted_timeout_nanos =
+        adjusted_timeout_nanos - elapsed_time_nanos;
+
+    // Wait on the GPU to signal the fence.
+    GLenum wait_return = glClientWaitSync(fence_id, GL_SYNC_FLUSH_COMMANDS_BIT,
+                                          readjusted_timeout_nanos.count());
+    switch (wait_return) {
+      case GL_CONDITION_SATISFIED:
+      case GL_ALREADY_SIGNALED: {
+        // Flag signaled state so we can quickly query in the future.
+        std::lock_guard<std::mutex> lock_guard(mutex_);
+        is_signaled_ = true;
+        wait_result = WaitResult::kSuccess;
+        break;
+      }
+      case GL_TIMEOUT_EXPIRED:
+        wait_result = WaitResult::kTimeout;
+        break;
+      case GL_WAIT_FAILED:
+      default:
+        wait_result = WaitResult::kDeviceLost;
+        break;
+    }
+
+    return true;
+  });
+  return wait_result;
 }
 
 void ES3QueueFence::WaitOnServer(std::chrono::nanoseconds timeout_nanos) {
+  ES3PlatformContext::CheckHasContextLock();
+
+  ref_ptr<ES3QueueFence> self_ref{this};
+
+  // Wait for the fence to be issued as we need a fence ID to pass to GL.
+  // If the fence has already been signaled this will return immediately.
   std::chrono::nanoseconds adjusted_timeout_nanos = timeout_nanos;
   GLsync fence_id = 0;
   WaitResult wait_result = WaitForIssue(&adjusted_timeout_nanos, &fence_id);
@@ -105,20 +229,43 @@ void ES3QueueFence::WaitOnServer(std::chrono::nanoseconds timeout_nanos) {
     return;
   }
 
+  {
+    // Check if we were signaled already.
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    if (is_signaled_) {
+      return;
+    }
+  }
+  DCHECK(fence_id);
+
   // NOTE: unfortunately GL does not support server timeouts so we have to pass
   //       IGNORED. We still use the timeout when waiting for issue, though.
   glWaitSync(fence_id, 0, GL_TIMEOUT_IGNORED);
+
+  {
+    // Flag signaled state so we can quickly query in the future.
+    std::lock_guard<std::mutex> lock_guard(mutex_);
+    is_signaled_ = true;
+  }
 }
 
 ES3QueueFence::WaitResult ES3QueueFence::WaitForIssue(
     std::chrono::nanoseconds* timeout_nanos, GLsync* out_fence_id) {
   GLsync fence_id = 0;
+  bool is_signaled = false;
   {
     std::lock_guard<std::mutex> lock_guard(mutex_);
     fence_id = fence_id_;
+    is_signaled = is_signaled_;
   }
-  if (fence_id) {
-    // Already have a fence object.
+  if (is_signaled) {
+    // Already signaled either on the client or server. The caller should
+    // also check for this and early-exit.
+    *out_fence_id = 0;
+    return WaitResult::kSuccess;
+  } else if (fence_id) {
+    // Have been issued and have a fence object. We'll wait on it in the caller
+    // with the GL wait primitives.
     *out_fence_id = fence_id;
     return WaitResult::kSuccess;
   }

--- a/xrtl/gfx/es3/es3_queue_fence.h
+++ b/xrtl/gfx/es3/es3_queue_fence.h
@@ -19,45 +19,77 @@
 
 #include "xrtl/base/threading/event.h"
 #include "xrtl/gfx/es3/es3_common.h"
-#include "xrtl/gfx/es3/es3_platform_context.h"
+#include "xrtl/gfx/es3/es3_queue_object.h"
 #include "xrtl/gfx/queue_fence.h"
 
 namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-// NOTE: special care is taken here as we can only get a fence object from GL
-// when we issue it into the command stream, yet our API allows fences to be
-// created without being signaled. We use a CPU-side Event fence to wait until
-// issuing before we ever try to query/wait on GL.
-class ES3QueueFence : public QueueFence {
+// Shoddy implementation of a QueueFence.
+// The design of fences in GL is pretty jank and the implementations are even
+// worse on most Android drivers (especially multi-context). We implement a
+// hybrid here that allows for QueueFence to be signaled and waited on entirely
+// on the CPU when used only for queue execution ordering.
+//
+// As GL only allocates fence IDs when the fences are signaled we take care to
+// enable waiting on the fence before the ID has been allocated via a CPU-side
+// issued_fence_. Only once it's been issued do we allow the GL fence waiting
+// APIs to be used.
+//
+// For purely client-side operations, most specifically present queue/swap chain
+// signaling, we support SignalClient as a way to only use the issued_fence_ and
+// a flag to perform the fence operation. This is not correct behavior in non-GL
+// APIs like Vulkan/Metal, but works well enough for GLs model. The gotcha is
+// that if we were really waiting for issued commands to complete to synchronize
+// memory it's not guaranteed to have happened. Since we primarily use this
+// when swapping that's fine as a SwapBuffers pretty much synchronizes with the
+// server.
+class ES3QueueFence : public QueueFence, public ES3QueueObject {
  public:
-  explicit ES3QueueFence(ref_ptr<ES3PlatformContext> platform_context);
+  explicit ES3QueueFence(ES3ObjectLifetimeQueue* queue);
   ~ES3QueueFence() override;
 
-  bool IsSignaled() override;
+  FenceState QueryState() override;
+
+  // Issues a fence. If this is called from a thread that has a GL context it is
+  // equivalent to calling SignalServer, and otherwise falls back to
+  // SignalClient.
+  void Signal();
+
+  // Issues an immediate client-side signal, avoiding the GL server entirely.
+  // This may be called from any thread.
+  void SignalClient();
 
   // Issues a glFenceSync to signal the fence in the current context command
-  // stream.
-  void Signal();
+  // stream. The command stream must be flushed to ensure the fence makes it to
+  // the server.
+  void SignalServer() XRTL_REQUIRES_GL_CONTEXT;
 
   WaitResult Wait(std::chrono::nanoseconds timeout_nanos) override;
 
   // Performs a wait on the GL server. The CPU will not block.
   // Assumes a context is active to insert the wait into.
-  void WaitOnServer(std::chrono::nanoseconds timeout_nanos);
+  void WaitOnServer(std::chrono::nanoseconds timeout_nanos)
+      XRTL_REQUIRES_GL_CONTEXT;
 
  private:
+  void Release() override;
+  bool AllocateOnQueue() override;
+  void DeallocateOnQueue() override;
+
   // Waits for the fence to be created.
   // Returns kSuccess if the fence_id_ object is valid. timeout_nanos will be
   // adjusted for the remaining timeout after waiting.
   WaitResult WaitForIssue(std::chrono::nanoseconds* timeout_nanos,
                           GLsync* out_fence_id);
 
-  ref_ptr<ES3PlatformContext> platform_context_;
+  ES3ObjectLifetimeQueue* queue_;
   ref_ptr<Event> issued_fence_;
   std::mutex mutex_;
   GLsync fence_id_ = 0;
+  bool is_issued_ = false;
+  bool is_signaled_ = false;
 };
 
 }  // namespace es3

--- a/xrtl/gfx/es3/es3_queue_object.h
+++ b/xrtl/gfx/es3/es3_queue_object.h
@@ -1,0 +1,179 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_ES3_ES3_QUEUE_OBJECT_H_
+#define XRTL_GFX_ES3_ES3_QUEUE_OBJECT_H_
+
+#include <utility>
+
+#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/es3/es3_platform_context.h"
+
+namespace xrtl {
+namespace gfx {
+namespace es3 {
+
+// Interface for objects that are managed by an ES3Queue.
+// Implementing this allows an object to have its lifetime lazily managed on the
+// queue. This is used for GL objects where otherwise a GL context would be
+// required on any thread attempting to alloc/dealloc an object.
+//
+// Objects implementing this interface must take care to make themselves either
+// immutable after initial creation or thread-safe. They must also be consistent
+// in their usage of the queue and not try to work around it (by, say, issuing
+// GL calls anywhere but in the callbacks defined by the interface).
+//
+// For example, if you had an object owning a GL resource as follows:
+//   class Foo {
+//     Foo() { my_id_ = glCreateFoo(); }
+//     ~Foo() { glDeleteFoo(my_id_); }
+//     int some_query() { return glGet(GL_FOO, my_id_); }
+//     int SyncCall() { return glFoo(my_id_); }
+//   };
+// The queue variant would look like:
+//   class Foo : public ManagedObject, public ES3QueueObject {
+//     explicit Foo(ES3ObjectLifetimeQueue* queue) : queue_(queue) {
+//       queue_->EnqueueObjectAllocation(this);
+//     }
+//     void Release() override { queue_->EnqueueObjectDeallocation(this); }
+//     bool AllocateOnQueue() {
+//       my_id_ = glCreateFoo();
+//       cached_value_ = glGet(GL_FOO, my_id_);
+//     }
+//     void DeallocateOnQueue() { glDeleteFoo(my_id_); }
+//     int some_query() { return cached_value_; }
+//     int SyncCall() {
+//       int value = 0;
+//       queue_->SyncObjectCallback(this, [&value]() {
+//         value = glFoo(my_id_);
+//       });
+//       return value;
+//     }
+//   };
+class ES3QueueObject {
+ public:
+  virtual ~ES3QueueObject() = default;
+
+ protected:
+  friend class ES3ObjectLifetimeQueue;
+
+  ES3QueueObject() = default;
+
+  // Allocates the object from the queue thread.
+  // This is called once per object prior to validation/first use.
+  // A GL context will be locked and available for use during the call.
+  // Returns true if the object was allocated successfully and is available for
+  // use.
+  virtual bool AllocateOnQueue() XRTL_REQUIRES_GL_CONTEXT = 0;
+
+  // Deallocates the object from the queue thread.
+  // This is called once per object and always after allocation. This is
+  // effectively the destructor and no future use of the object will be made
+  // by the queue or any command buffers.
+  // A GL context will be locked and available for use during the call.
+  virtual void DeallocateOnQueue() XRTL_REQUIRES_GL_CONTEXT = 0;
+};
+
+// Interface for work queues that are used to manage object lifetime.
+// ES3QueueObjects use these queues to run their allocation routines and
+// callbacks that require a locked platform context to operate.
+class ES3ObjectLifetimeQueue : public RefObject<ES3ObjectLifetimeQueue> {
+ public:
+  using ObjectReleaseCallback = void (*)(ES3QueueObject*);
+
+  virtual ~ES3ObjectLifetimeQueue() = default;
+
+  // Enqueues an object for allocation on the queue.
+  // The ES3QueueObject::AllocateOnQueue method will be called before any
+  // following queued commands execute.
+  //
+  // If provided a custom platform context can be specified for locking prior
+  // to executing the allocation; otherwise the queue context is used.
+  template <typename T>
+  void EnqueueObjectAllocation(
+      T* obj, ref_ptr<ES3PlatformContext> exclusive_context = nullptr) {
+    obj->AddReference();
+    EnqueueObjectCallback(
+        static_cast<ES3QueueObject*>(obj),
+        [](ES3QueueObject* obj) { static_cast<T*>(obj)->ReleaseReference(); },
+        [obj]() { static_cast<ES3QueueObject*>(obj)->AllocateOnQueue(); },
+        std::move(exclusive_context));
+  }
+
+  // Enqueues an object for deallocation on the queue.
+  // The ES3QueueObject::DeallocateOnQueue method will be called before any
+  // following queued commands execute. The object will be deleted prior to the
+  // return of the function.
+  //
+  // If provided a custom platform context can be specified for locking prior
+  // to executing the deallocation; otherwise the queue context is used.
+  template <typename T>
+  void EnqueueObjectDeallocation(
+      T* obj, ref_ptr<ES3PlatformContext> exclusive_context = nullptr) {
+    EnqueueObjectCallback(
+        static_cast<ES3QueueObject*>(obj),
+        [](ES3QueueObject* obj) { delete static_cast<T*>(obj); },
+        [obj]() { static_cast<ES3QueueObject*>(obj)->DeallocateOnQueue(); },
+        std::move(exclusive_context));
+  }
+
+  // Enqueues an asynchronous object-specific callback on the queue.
+  // The callback will be called before any following queued commands execute.
+  //
+  // If provided a custom platform context can be specified for locking prior
+  // to executing the callback; otherwise the queue context is used.
+  template <typename T>
+  void EnqueueObjectCallback(
+      T* obj, std::function<void()> callback,
+      ref_ptr<ES3PlatformContext> exclusive_context = nullptr) {
+    obj->AddReference();
+    EnqueueObjectCallback(
+        static_cast<ES3QueueObject*>(obj),
+        [](ES3QueueObject* obj) { static_cast<T*>(obj)->ReleaseReference(); },
+        std::move(callback), std::move(exclusive_context));
+  }
+
+  // Enqueues a synchronous object-specific callback on the queue.
+  // The callback will be called before any following queued commands execute.
+  // Returns the result of the callback or false if the callback could not be
+  // executed.
+  //
+  // If provided a custom platform context can be specified for locking prior
+  // to executing the callback; otherwise the queue context is used.
+  template <typename T>
+  bool EnqueueObjectCallbackAndWait(
+      T* obj, std::function<bool()> callback,
+      ref_ptr<ES3PlatformContext> exclusive_context = nullptr) {
+    return SyncObjectCallback(static_cast<ES3QueueObject*>(obj),
+                              std::move(callback),
+                              std::move(exclusive_context));
+  }
+
+ protected:
+  ES3ObjectLifetimeQueue() = default;
+
+  virtual void EnqueueObjectCallback(
+      ES3QueueObject* obj, ObjectReleaseCallback release_callback,
+      std::function<void()> callback,
+      ref_ptr<ES3PlatformContext> exclusive_context) = 0;
+  virtual bool SyncObjectCallback(
+      ES3QueueObject* obj, std::function<bool()> callback,
+      ref_ptr<ES3PlatformContext> exclusive_context) = 0;
+};
+
+}  // namespace es3
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_ES3_ES3_QUEUE_OBJECT_H_

--- a/xrtl/gfx/es3/es3_sampler.cc
+++ b/xrtl/gfx/es3/es3_sampler.cc
@@ -14,15 +14,23 @@
 
 #include "xrtl/gfx/es3/es3_sampler.h"
 
+#include "xrtl/gfx/es3/es3_platform_context.h"
+
 namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-ES3Sampler::ES3Sampler(ref_ptr<ES3PlatformContext> platform_context,
-                       Params params)
-    : Sampler(params), platform_context_(std::move(platform_context)) {
-  auto context_lock =
-      ES3PlatformContext::LockTransientContext(platform_context_);
+ES3Sampler::ES3Sampler(ES3ObjectLifetimeQueue* queue, Params params)
+    : Sampler(params), queue_(queue) {
+  queue_->EnqueueObjectAllocation(this);
+}
+
+ES3Sampler::~ES3Sampler() = default;
+
+void ES3Sampler::Release() { queue_->EnqueueObjectDeallocation(this); }
+
+bool ES3Sampler::AllocateOnQueue() {
+  ES3PlatformContext::CheckHasContextLock();
 
   // TODO(benvanik): pool ID allocation.
   glGenSamplers(1, &sampler_id_);
@@ -33,17 +41,20 @@ ES3Sampler::ES3Sampler(ref_ptr<ES3PlatformContext> platform_context,
       GL_CLAMP_TO_EDGE,    // kClampToEdge
       GL_CLAMP_TO_EDGE,    // kClampToBorder (not supported?)
   };
-  glSamplerParameteri(sampler_id_, GL_TEXTURE_WRAP_S,
-                      kTextureWrapMap[static_cast<int>(params.address_mode_u)]);
-  glSamplerParameteri(sampler_id_, GL_TEXTURE_WRAP_T,
-                      kTextureWrapMap[static_cast<int>(params.address_mode_v)]);
-  glSamplerParameteri(sampler_id_, GL_TEXTURE_WRAP_R,
-                      kTextureWrapMap[static_cast<int>(params.address_mode_w)]);
+  glSamplerParameteri(
+      sampler_id_, GL_TEXTURE_WRAP_S,
+      kTextureWrapMap[static_cast<int>(params_.address_mode_u)]);
+  glSamplerParameteri(
+      sampler_id_, GL_TEXTURE_WRAP_T,
+      kTextureWrapMap[static_cast<int>(params_.address_mode_v)]);
+  glSamplerParameteri(
+      sampler_id_, GL_TEXTURE_WRAP_R,
+      kTextureWrapMap[static_cast<int>(params_.address_mode_w)]);
 
   GLint min_filter = GL_NEAREST;
-  switch (params.min_filter) {
+  switch (params_.min_filter) {
     case Filter::kNearest:
-      switch (params.mipmap_mode) {
+      switch (params_.mipmap_mode) {
         case MipmapMode::kNearest:
           min_filter = GL_NEAREST_MIPMAP_NEAREST;
           break;
@@ -53,7 +64,7 @@ ES3Sampler::ES3Sampler(ref_ptr<ES3PlatformContext> platform_context,
       }
       break;
     case Sampler::Filter::kLinear:
-      switch (params.mipmap_mode) {
+      switch (params_.mipmap_mode) {
         case MipmapMode::kNearest:
           min_filter = GL_LINEAR_MIPMAP_NEAREST;
           break;
@@ -66,7 +77,7 @@ ES3Sampler::ES3Sampler(ref_ptr<ES3PlatformContext> platform_context,
   glSamplerParameteri(sampler_id_, GL_TEXTURE_MIN_FILTER, min_filter);
 
   GLint mag_filter = GL_NEAREST;
-  switch (params.mag_filter) {
+  switch (params_.mag_filter) {
     case Filter::kNearest:
       mag_filter = GL_NEAREST;
       break;
@@ -76,19 +87,23 @@ ES3Sampler::ES3Sampler(ref_ptr<ES3PlatformContext> platform_context,
   }
   glSamplerParameteri(sampler_id_, GL_TEXTURE_MAG_FILTER, mag_filter);
 
-  glSamplerParameterf(sampler_id_, GL_TEXTURE_MIN_LOD, params.min_lod);
-  glSamplerParameterf(sampler_id_, GL_TEXTURE_MAX_LOD, params.max_lod);
+  glSamplerParameterf(sampler_id_, GL_TEXTURE_MIN_LOD, params_.min_lod);
+  glSamplerParameterf(sampler_id_, GL_TEXTURE_MAX_LOD, params_.max_lod);
 
   // TODO(benvanik): params.mip_lod_bias
   // TODO(benvanik): params.anisotropy_enable
   // TODO(benvanik): params.max_anisotropy
   // TODO(benvanik): params.border_color
+
+  return true;
 }
 
-ES3Sampler::~ES3Sampler() {
-  auto context_lock =
-      ES3PlatformContext::LockTransientContext(platform_context_);
-  glDeleteSamplers(1, &sampler_id_);
+void ES3Sampler::DeallocateOnQueue() {
+  ES3PlatformContext::CheckHasContextLock();
+  if (sampler_id_) {
+    glDeleteSamplers(1, &sampler_id_);
+    sampler_id_ = 0;
+  }
 }
 
 }  // namespace es3

--- a/xrtl/gfx/es3/es3_sampler.h
+++ b/xrtl/gfx/es3/es3_sampler.h
@@ -18,22 +18,26 @@
 #include <utility>
 
 #include "xrtl/gfx/es3/es3_common.h"
-#include "xrtl/gfx/es3/es3_platform_context.h"
+#include "xrtl/gfx/es3/es3_queue_object.h"
 #include "xrtl/gfx/sampler.h"
 
 namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-class ES3Sampler : public Sampler {
+class ES3Sampler : public Sampler, public ES3QueueObject {
  public:
-  ES3Sampler(ref_ptr<ES3PlatformContext> platform_context, Params params);
+  ES3Sampler(ES3ObjectLifetimeQueue* queue, Params params);
   ~ES3Sampler() override;
 
   GLuint sampler_id() const { return sampler_id_; }
 
  private:
-  ref_ptr<ES3PlatformContext> platform_context_;
+  void Release() override;
+  bool AllocateOnQueue() override;
+  void DeallocateOnQueue() override;
+
+  ES3ObjectLifetimeQueue* queue_;
   GLuint sampler_id_ = 0;
 };
 

--- a/xrtl/gfx/es3/es3_shader_module.cc
+++ b/xrtl/gfx/es3/es3_shader_module.cc
@@ -20,10 +20,18 @@ namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-ES3ShaderModule::ES3ShaderModule(ref_ptr<ES3PlatformContext> platform_context)
-    : platform_context_(std::move(platform_context)) {}
+ES3ShaderModule::ES3ShaderModule(ES3ObjectLifetimeQueue* queue)
+    : queue_(queue) {
+  queue_->EnqueueObjectAllocation(this);
+}
 
-ES3ShaderModule::~ES3ShaderModule() { shaders_.clear(); }
+ES3ShaderModule::~ES3ShaderModule() = default;
+
+void ES3ShaderModule::Release() { queue_->EnqueueObjectDeallocation(this); }
+
+bool ES3ShaderModule::AllocateOnQueue() { return true; }
+
+void ES3ShaderModule::DeallocateOnQueue() { shaders_.clear(); }
 
 void ES3ShaderModule::Register(ref_ptr<ES3Shader> shader) {
   shaders_.push_back(shader);

--- a/xrtl/gfx/es3/es3_shader_module.h
+++ b/xrtl/gfx/es3/es3_shader_module.h
@@ -20,7 +20,7 @@
 
 #include "absl/strings/string_view.h"
 #include "xrtl/gfx/es3/es3_common.h"
-#include "xrtl/gfx/es3/es3_platform_context.h"
+#include "xrtl/gfx/es3/es3_queue_object.h"
 #include "xrtl/gfx/es3/es3_shader.h"
 #include "xrtl/gfx/shader_module.h"
 
@@ -28,9 +28,9 @@ namespace xrtl {
 namespace gfx {
 namespace es3 {
 
-class ES3ShaderModule : public ShaderModule {
+class ES3ShaderModule : public ShaderModule, public ES3QueueObject {
  public:
-  explicit ES3ShaderModule(ref_ptr<ES3PlatformContext> platform_context);
+  explicit ES3ShaderModule(ES3ObjectLifetimeQueue* queue);
   ~ES3ShaderModule() override;
 
   // Registers a shader with the shader module.
@@ -42,7 +42,11 @@ class ES3ShaderModule : public ShaderModule {
   ref_ptr<ES3Shader> Lookup(absl::string_view entry_point) const;
 
  private:
-  ref_ptr<ES3PlatformContext> platform_context_;
+  void Release() override;
+  bool AllocateOnQueue() override;
+  void DeallocateOnQueue() override;
+
+  ES3ObjectLifetimeQueue* queue_;
   std::vector<ref_ptr<ES3Shader>> shaders_;
 };
 

--- a/xrtl/gfx/framebuffer.h
+++ b/xrtl/gfx/framebuffer.h
@@ -20,18 +20,16 @@
 #include "absl/container/inlined_vector.h"
 #include "absl/types/span.h"
 #include "xrtl/base/geometry.h"
-#include "xrtl/base/ref_ptr.h"
 #include "xrtl/gfx/image_view.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/render_pass.h"
 
 namespace xrtl {
 namespace gfx {
 
 // A render target framebuffer, composed of one or more attachments.
-class Framebuffer : public RefObject<Framebuffer> {
+class Framebuffer : public ManagedObject {
  public:
-  virtual ~Framebuffer() = default;
-
   // Render pass this framebuffer is used with.
   ref_ptr<RenderPass> render_pass() const { return render_pass_; }
   // Dimensions of the framebuffer in pixels.

--- a/xrtl/gfx/image_view.h
+++ b/xrtl/gfx/image_view.h
@@ -17,8 +17,8 @@
 
 #include <utility>
 
-#include "xrtl/base/ref_ptr.h"
 #include "xrtl/gfx/image.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/pixel_format.h"
 
 namespace xrtl {
@@ -26,10 +26,8 @@ namespace gfx {
 
 // A view into an existing Image resource, possibly with a different type or
 // format and some subregion of the layers available.
-class ImageView : public RefObject<ImageView> {
+class ImageView : public ManagedObject {
  public:
-  virtual ~ImageView() = default;
-
   // Image this view is into.
   ref_ptr<Image> image() const { return image_; }
   // Image type the view is representing.

--- a/xrtl/gfx/managed_object.h
+++ b/xrtl/gfx/managed_object.h
@@ -1,0 +1,44 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XRTL_GFX_MANAGED_OBJECT_H_
+#define XRTL_GFX_MANAGED_OBJECT_H_
+
+#include "xrtl/base/ref_ptr.h"
+
+namespace xrtl {
+namespace gfx {
+
+// Base type for objects managed by the graphics system.
+// These objects may have differing lifetime rules based on the underlying
+// implementation.
+class ManagedObject : public RefObject<ManagedObject> {
+ public:
+  virtual ~ManagedObject() = default;
+
+  // Deleter used by RefObject instead of normal C++ delete.
+  static void Delete(ManagedObject* obj) { obj->Release(); }
+
+ protected:
+  ManagedObject() = default;
+
+  // Implementation subclasses may override this to perform custom destruction
+  // logic, such as returning to a pool or deferring deletion to another thread.
+  virtual void Release() { delete this; }
+};
+
+}  // namespace gfx
+}  // namespace xrtl
+
+#endif  // XRTL_GFX_MANAGED_OBJECT_H_

--- a/xrtl/gfx/memory_heap.h
+++ b/xrtl/gfx/memory_heap.h
@@ -16,9 +16,9 @@
 #define XRTL_GFX_MEMORY_HEAP_H_
 
 #include "xrtl/base/macros.h"
-#include "xrtl/base/ref_ptr.h"
 #include "xrtl/gfx/buffer.h"
 #include "xrtl/gfx/image.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/resource.h"
 
 namespace xrtl {
@@ -56,10 +56,8 @@ namespace gfx {
 // - D3D12: ID3D12Heap
 // - Metal: MTLHeap
 // - Vulkan: VkMemoryHeap
-class MemoryHeap : public RefObject<MemoryHeap> {
+class MemoryHeap : public ManagedObject {
  public:
-  virtual ~MemoryHeap() = default;
-
   // TODO(benvanik): expose stats (total chunk size, chunks allocated, etc).
   // TODO(benvanik): expose properties to query granularities for mapping/etc.
 

--- a/xrtl/gfx/pipeline.h
+++ b/xrtl/gfx/pipeline.h
@@ -19,7 +19,7 @@
 #include <utility>
 
 #include "absl/strings/string_view.h"
-#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/pipeline_layout.h"
 #include "xrtl/gfx/render_state.h"
 #include "xrtl/gfx/shader_module.h"
@@ -28,10 +28,8 @@ namespace xrtl {
 namespace gfx {
 
 // Base shader pipeline.
-class Pipeline : public RefObject<Pipeline> {
+class Pipeline : public ManagedObject {
  public:
-  virtual ~Pipeline() = default;
-
   // Layout of the pipeline denoting what other pipelines it is compatible with.
   ref_ptr<PipelineLayout> pipeline_layout() const { return pipeline_layout_; }
 
@@ -45,8 +43,6 @@ class Pipeline : public RefObject<Pipeline> {
 // A pipeline used for compute operations.
 class ComputePipeline : public Pipeline {
  public:
-  ~ComputePipeline() override = default;
-
   // Source shader module.
   ref_ptr<ShaderModule> shader_module() const { return shader_module_; }
   // Entry point name within the shader module.
@@ -86,8 +82,6 @@ class RenderPipeline : public Pipeline {
     ref_ptr<ShaderModule> fragment_shader_module;
     std::string fragment_entry_point;
   };
-
-  ~RenderPipeline() override = default;
 
   // Render pass the pipeline is used in.
   ref_ptr<RenderPass> render_pass() const { return render_pass_; }

--- a/xrtl/gfx/pipeline_layout.h
+++ b/xrtl/gfx/pipeline_layout.h
@@ -17,7 +17,7 @@
 
 #include "absl/container/inlined_vector.h"
 #include "absl/types/span.h"
-#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/resource_set_layout.h"
 
 namespace xrtl {

--- a/xrtl/gfx/queue_fence.h
+++ b/xrtl/gfx/queue_fence.h
@@ -17,7 +17,7 @@
 
 #include <chrono>
 
-#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/managed_object.h"
 
 namespace xrtl {
 namespace gfx {
@@ -35,13 +35,21 @@ namespace gfx {
 // - Metal: (emulated)
 // - OpenGL: glFenceSync (kind of)
 // - Vulkan: VkSemaphore
-class QueueFence : public RefObject<QueueFence> {
+class QueueFence : public ManagedObject {
  public:
-  virtual ~QueueFence() = default;
+  // Describes the state of a queue fence.
+  enum class FenceState {
+    // Fence has been signaled.
+    kSignaled,
+    // Fence has yet to be signaled.
+    kUnsignaled,
+    // Device was lost and the fence will never be signaled.
+    kDeviceLost,
+  };
 
   // Queries the current status of the queue fence without blocking.
   // Returns true if the fence has been signaled.
-  virtual bool IsSignaled() = 0;
+  virtual FenceState QueryState() = 0;
 
   // Defines the return value for QueueFence wait operations.
   enum class WaitResult {

--- a/xrtl/gfx/render_pass.h
+++ b/xrtl/gfx/render_pass.h
@@ -18,8 +18,8 @@
 #include "absl/container/inlined_vector.h"
 #include "absl/types/span.h"
 #include "xrtl/base/macros.h"
-#include "xrtl/base/ref_ptr.h"
 #include "xrtl/gfx/image.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/pixel_format.h"
 #include "xrtl/gfx/render_state.h"
 
@@ -189,7 +189,7 @@ enum class AccessFlag : uint32_t {
 };
 XRTL_BITMASK(AccessFlag);
 
-class RenderPass : public RefObject<RenderPass> {
+class RenderPass : public ManagedObject {
  public:
   // A sentinel that can be used in place of subpass indices to denote an
   // external data source. This may be used as a source to denote input
@@ -344,8 +344,6 @@ class RenderPass : public RefObject<RenderPass> {
     AccessFlag target_access_mask;
     PipelineDependencyFlag dependency_flags;
   };
-
-  virtual ~RenderPass() = default;
 
   // A list of attachment descriptions.
   // Framebuffers must contain attachments corresponding to the indices of the

--- a/xrtl/gfx/resource.h
+++ b/xrtl/gfx/resource.h
@@ -17,7 +17,7 @@
 
 #include <cstdint>
 
-#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/managed_object.h"
 
 namespace xrtl {
 namespace gfx {
@@ -25,10 +25,8 @@ namespace gfx {
 class MemoryHeap;
 
 // Base type for allocated resources.
-class Resource : public RefObject<Resource> {
+class Resource : public ManagedObject {
  public:
-  virtual ~Resource() = default;
-
   // The memory heap this resource was allocated from.
   // The heap will be kept alive so long as this resource remains allocated.
   virtual ref_ptr<MemoryHeap> memory_heap() const = 0;
@@ -38,14 +36,9 @@ class Resource : public RefObject<Resource> {
   // size for the resource based on device restrictions.
   size_t allocation_size() const { return allocation_size_; }
 
-  static void Delete(Resource* resource) { resource->Release(); }
-
  protected:
   explicit Resource(size_t allocation_size)
       : allocation_size_(allocation_size) {}
-
-  // Releases the resource back to its heap.
-  virtual void Release() = 0;
 
   size_t allocation_size_ = 0;
 };

--- a/xrtl/gfx/resource_set.h
+++ b/xrtl/gfx/resource_set.h
@@ -21,10 +21,10 @@
 
 #include "absl/container/inlined_vector.h"
 #include "absl/types/span.h"
-#include "xrtl/base/ref_ptr.h"
 #include "xrtl/gfx/buffer.h"
 #include "xrtl/gfx/image.h"
 #include "xrtl/gfx/image_view.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/resource_set_layout.h"
 #include "xrtl/gfx/sampler.h"
 
@@ -98,10 +98,8 @@ struct BindingValue {
 // - D3D12: descriptor tables
 // - Metal: argument buffers
 // - Vulkan: descriptor sets
-class ResourceSet : public RefObject<ResourceSet> {
+class ResourceSet : public ManagedObject {
  public:
-  virtual ~ResourceSet() = default;
-
   // Layout the resource set uses.
   ref_ptr<ResourceSetLayout> layout() const { return layout_; }
 

--- a/xrtl/gfx/resource_set_layout.h
+++ b/xrtl/gfx/resource_set_layout.h
@@ -17,7 +17,7 @@
 
 #include "absl/container/inlined_vector.h"
 #include "absl/types/span.h"
-#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/render_pass.h"
 
 namespace xrtl {
@@ -72,11 +72,9 @@ struct BindingSlot {
 // - D3D12: descriptor tables
 // - Metal: argument buffers
 // - Vulkan: descriptor set layouts
-class ResourceSetLayout : public RefObject<ResourceSetLayout> {
+class ResourceSetLayout : public ManagedObject {
  public:
   static constexpr int kInlinedBindingSlotCount = 8;
-
-  virtual ~ResourceSetLayout() = default;
 
   absl::Span<const BindingSlot> binding_slots() const { return binding_slots_; }
 

--- a/xrtl/gfx/sampler.h
+++ b/xrtl/gfx/sampler.h
@@ -15,12 +15,12 @@
 #ifndef XRTL_GFX_SAMPLER_H_
 #define XRTL_GFX_SAMPLER_H_
 
-#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/managed_object.h"
 
 namespace xrtl {
 namespace gfx {
 
-class Sampler : public RefObject<Sampler> {
+class Sampler : public ManagedObject {
  public:
   // Specifies filters used for image lookups.
   enum class Filter {
@@ -84,8 +84,6 @@ class Sampler : public RefObject<Sampler> {
     // TODO(benvanik): verify this can be supported everywhere.
     // bool unnormalized_coordinates = false;
   };
-
-  virtual ~Sampler() = default;
 
   // Sampler parameters.
   const Params& params() const { return params_; }

--- a/xrtl/gfx/shader_module.h
+++ b/xrtl/gfx/shader_module.h
@@ -15,22 +15,20 @@
 #ifndef XRTL_GFX_SHADER_MODULE_H_
 #define XRTL_GFX_SHADER_MODULE_H_
 
-#include "xrtl/base/ref_ptr.h"
+#include "xrtl/gfx/managed_object.h"
 
 namespace xrtl {
 namespace gfx {
 
 // A module of shader code.
 // Each module may contain multiple entry points that can be used by pipelines.
-class ShaderModule : public RefObject<ShaderModule> {
+class ShaderModule : public ManagedObject {
  public:
   // Describes the format of shader module data.
   enum class DataFormat {
     // Standard SPIR-V.
     kSpirV,
   };
-
-  virtual ~ShaderModule() = default;
 
  protected:
   ShaderModule() = default;

--- a/xrtl/gfx/swap_chain.h
+++ b/xrtl/gfx/swap_chain.h
@@ -19,10 +19,10 @@
 #include <utility>
 
 #include "xrtl/base/geometry.h"
-#include "xrtl/base/ref_ptr.h"
 #include "xrtl/gfx/command_buffer.h"
 #include "xrtl/gfx/image.h"
 #include "xrtl/gfx/image_view.h"
+#include "xrtl/gfx/managed_object.h"
 #include "xrtl/gfx/pixel_format.h"
 #include "xrtl/gfx/queue_fence.h"
 
@@ -60,10 +60,8 @@ namespace gfx {
 //  // Asynchronously present the image.
 //  swap_chain->PresentImage(std::move(rendered_fence),
 //                           std::move(image_view));
-class SwapChain : public RefObject<SwapChain> {
+class SwapChain : public ManagedObject {
  public:
-  virtual ~SwapChain() = default;
-
   // Defines the presentation queueing mode used by the swap chain.
   //
   // See section 20 here for more information:


### PR DESCRIPTION
This prevents us from requiring multiple GL contexts and makes GL use much
easier to debug. With this set of changes we now create 3 contexts in
normal cases - one for factory/querying, one for each gfx::Context, and
one for each EGL gfx::SwapChain backed by a native surface. The factory
context could potentially be optimized out on EGL (but not WGL).

This is accomplished with the ES3QueueObject interface that allows objects
to describe what operations should run with a GL context and a mechanism to
marshal those operations to the queue that owns that context.

GLSL shader compilation/program linking now happen on the queue threads,
which is nice for main thread perf but obscures errors. Will need to think
of a better solution to this in the long term (besides CHECKing).

There's a lot of room for efficiency improvements here particularly around
ES3QueueFence's signal/query, though since these are implementation details
specific to ES3 and not problems with the gfx API they're ok for now.

Future work remains around defining better primitives on Buffer and Image
for dynamic upload/download, potentially with a dedicated ES3 transfer
queue. With this CL they become blocking queue ops and map/unmap is
particularly bad.