### PR TITLE
Making buffer/texture upload/download more portable.

### DIFF
--- a/xrtl/examples/triangle_example.cc
+++ b/xrtl/examples/triangle_example.cc
@@ -116,8 +116,8 @@ class TriangleExample : private Control::Listener {
 
     // Write data directly into the buffer.
     // A real app would want to use a staging buffer.
-    bool did_write =
-        triangle_buffer_->WriteData(0, kVertexData, sizeof(kVertexData));
+    bool did_write = context_->WriteBufferData(
+        triangle_buffer_, {{0, kVertexData, sizeof(kVertexData)}});
     CHECK(did_write);
   }
 

--- a/xrtl/examples/triangle_full_example.cc
+++ b/xrtl/examples/triangle_full_example.cc
@@ -162,7 +162,8 @@ class TriangleFullExample : private Control::Listener {
 
     // Write data directly into the buffer.
     // A real app would want to use a staging buffer.
-    if (!triangle_buffer_->WriteData(0, kVertexData, sizeof(kVertexData))) {
+    if (!context_->WriteBufferData(triangle_buffer_,
+                                   {{0, kVertexData, sizeof(kVertexData)}})) {
       LOG(ERROR) << "Failed to write data into geometry buffer";
       return false;
     }
@@ -203,8 +204,9 @@ class TriangleFullExample : private Control::Listener {
 
     // Write data directly into the image.
     // A real app would want to use a staging buffer.
-    if (!grid_image_->WriteData(grid_image_->entire_range(), image_data.data(),
-                                image_data.size() * 4)) {
+    if (!context_->WriteImageData(
+            grid_image_, {{grid_image_->entire_range(), image_data.data(),
+                           image_data.size() * 4}})) {
       LOG(ERROR) << "Failed to write data into texture image";
       return false;
     }

--- a/xrtl/gfx/buffer.h
+++ b/xrtl/gfx/buffer.h
@@ -22,35 +22,6 @@ namespace gfx {
 
 class Buffer;
 
-// A bitmask specifying properties for a memory type.
-enum class MemoryType {
-  // Memory allocated with this type is the most efficient for device access.
-  kDeviceLocal = 1 << 0,
-
-  // Memory allocated with this type can be mapped for host access using
-  // Resource::MapMemory.
-  kHostVisible = 1 << 1,
-
-  // The host cache management commands MappedMemory::Flush and
-  // MappedMemory::Invalidate are not needed to flush host writes
-  // to the device or make device writes visible to the host, respectively.
-  kHostCoherent = 1 << 2,
-
-  // Memory allocated with this type is cached on the host. Host memory accesses
-  // to uncached memory are slower than to cached memory, however uncached
-  // memory is always host coherent.
-  kHostCached = 1 << 3,
-
-  // Memory is lazily allocated by the hardware and only exists transiently.
-  // This is the optimal mode for memory used only between subpasses in the same
-  // render pass, as it can often be kept entirely on-tile and discard when the
-  // render pass ends.
-  // The memory type only allows device access to the memory. Memory types must
-  // not have both this and kHostVisible set.
-  kLazilyAllocated = 1 << 4,
-};
-XRTL_BITMASK(MemoryType);
-
 // Defines how memory will be accessed in a mapped memory region.
 enum class MemoryAccess {
   // Memory will be read. Do not attempt to write to the buffer.
@@ -174,20 +145,6 @@ class Buffer : public Resource {
 
   // Bitmask describing how the buffer is to be used.
   Usage usage_mask() const { return usage_mask_; }
-
-  // Reads a block of data from the resource at the given offset.
-  //
-  // Returns false if the read could not be performed; either the bounds are
-  // out of range or the memory type does not support reading in this way.
-  virtual bool ReadData(size_t source_offset, void* data,
-                        size_t data_length) = 0;
-
-  // Writes a block of data into the resource at the given offset.
-  //
-  // Returns false if the write could not be performed; either the bounds are
-  // out of range or the memory type does not support writing in this way.
-  virtual bool WriteData(size_t target_offset, const void* data,
-                         size_t data_length) = 0;
 
   // Maps the resource memory for direct access from the host.
   // This requires that the resource was allocated with

--- a/xrtl/gfx/es3/BUILD
+++ b/xrtl/gfx/es3/BUILD
@@ -15,6 +15,7 @@ cc_library(
         ":es3_queue_object",
         "//xrtl/base:tracing",
         "//xrtl/gfx:buffer",
+        "//xrtl/gfx:context",
         "//xrtl/gfx:memory_heap",
     ],
 )
@@ -70,10 +71,12 @@ cc_library(
     srcs = ["es3_context.cc"],
     hdrs = ["es3_context.h"],
     deps = [
+        ":es3_buffer",
         ":es3_command_buffer",
         ":es3_command_fence",
         ":es3_common",
         ":es3_framebuffer",
+        ":es3_image",
         ":es3_image_view",
         ":es3_memory_heap",
         ":es3_pipeline",
@@ -147,6 +150,7 @@ cc_library(
         ":es3_platform_context",
         ":es3_queue_object",
         "//xrtl/base:tracing",
+        "//xrtl/gfx:context",
         "//xrtl/gfx:image",
         "//xrtl/gfx:memory_heap",
     ],

--- a/xrtl/gfx/es3/es3_buffer.h
+++ b/xrtl/gfx/es3/es3_buffer.h
@@ -18,6 +18,7 @@
 #include <functional>
 
 #include "xrtl/gfx/buffer.h"
+#include "xrtl/gfx/context.h"
 #include "xrtl/gfx/es3/es3_common.h"
 #include "xrtl/gfx/es3/es3_queue_object.h"
 
@@ -36,10 +37,10 @@ class ES3Buffer : public Buffer, public ES3QueueObject {
   GLenum target() const { return target_; }
   GLuint buffer_id() const { return buffer_id_; }
 
-  bool ReadData(size_t source_offset, void* data, size_t data_length) override;
-
-  bool WriteData(size_t target_offset, const void* data,
-                 size_t data_length) override;
+  void ReadDataRegionsOnQueue(absl::Span<const ReadBufferRegion> data_regions)
+      XRTL_REQUIRES_GL_CONTEXT;
+  void WriteDataRegionsOnQueue(absl::Span<const WriteBufferRegion> data_regions)
+      XRTL_REQUIRES_GL_CONTEXT;
 
   void InvalidateMappedMemory(size_t byte_offset, size_t byte_length) override;
 

--- a/xrtl/gfx/es3/es3_context.h
+++ b/xrtl/gfx/es3/es3_context.h
@@ -110,6 +110,40 @@ class ES3Context : public Context {
 
   WaitResult WaitUntilQueuesIdle(OperationQueueMask queue_mask) override;
 
+  bool ReadBufferData(ref_ptr<Buffer> source_buffer,
+                      absl::Span<const ReadBufferRegion> data_regions) override;
+  bool ReadBufferData(absl::Span<const ref_ptr<QueueFence>> wait_queue_fences,
+                      ref_ptr<Buffer> source_buffer,
+                      absl::Span<const ReadBufferRegion> data_regions,
+                      absl::Span<const ref_ptr<QueueFence>> signal_queue_fences,
+                      ref_ptr<Event> signal_handle) override;
+
+  bool WriteBufferData(
+      ref_ptr<Buffer> target_buffer,
+      absl::Span<const WriteBufferRegion> data_regions) override;
+  bool WriteBufferData(
+      absl::Span<const ref_ptr<QueueFence>> wait_queue_fences,
+      ref_ptr<Buffer> target_buffer,
+      absl::Span<const WriteBufferRegion> data_regions,
+      absl::Span<const ref_ptr<QueueFence>> signal_queue_fences,
+      ref_ptr<Event> signal_handle) override;
+
+  bool ReadImageData(ref_ptr<Image> source_image,
+                     absl::Span<const ReadImageRegion> data_regions) override;
+  bool ReadImageData(absl::Span<const ref_ptr<QueueFence>> wait_queue_fences,
+                     ref_ptr<Image> source_image,
+                     absl::Span<const ReadImageRegion> data_regions,
+                     absl::Span<const ref_ptr<QueueFence>> signal_queue_fences,
+                     ref_ptr<Event> signal_handle) override;
+
+  bool WriteImageData(ref_ptr<Image> target_image,
+                      absl::Span<const WriteImageRegion> data_regions) override;
+  bool WriteImageData(absl::Span<const ref_ptr<QueueFence>> wait_queue_fences,
+                      ref_ptr<Image> target_image,
+                      absl::Span<const WriteImageRegion> data_regions,
+                      absl::Span<const ref_ptr<QueueFence>> signal_queue_fences,
+                      ref_ptr<Event> signal_handle) override;
+
  private:
   static void QueueThreadMain(void* param);
   void RunQueue();

--- a/xrtl/gfx/es3/es3_image.h
+++ b/xrtl/gfx/es3/es3_image.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 
+#include "xrtl/gfx/context.h"
 #include "xrtl/gfx/es3/es3_common.h"
 #include "xrtl/gfx/es3/es3_pixel_format.h"
 #include "xrtl/gfx/es3/es3_queue_object.h"
@@ -45,11 +46,10 @@ class ES3Image : public Image, public ES3QueueObject {
                                 Image::LayerRange layer_range) override;
   ref_ptr<ImageView> CreateView(Image::Type type, PixelFormat format) override;
 
-  bool ReadData(LayerRange source_range, void* data,
-                size_t data_length) override;
-
-  bool WriteData(LayerRange target_range, const void* data,
-                 size_t data_length) override;
+  void ReadDataRegionsOnQueue(absl::Span<const ReadImageRegion> data_regions)
+      XRTL_REQUIRES_GL_CONTEXT;
+  void WriteDataRegionsOnQueue(absl::Span<const WriteImageRegion> data_regions)
+      XRTL_REQUIRES_GL_CONTEXT;
 
  private:
   void Release() override;

--- a/xrtl/gfx/es3/es3_swap_chain.cc
+++ b/xrtl/gfx/es3/es3_swap_chain.cc
@@ -310,14 +310,14 @@ SwapChain::PresentResult ES3PlatformSwapChain::PresentImage(
   // Submit present request to the context queue.
   auto self = ref_ptr<ES3PlatformSwapChain>(this);
   auto self_token = MoveToLambda(self);
-  present_queue_->EnqueueCallback(platform_context_, {wait_queue_fence},
-                                  [self_token, surface_size, image_index,
-                                   image_view, present_time_utc_millis]() {
-                                    self_token.value->PerformPresent(
-                                        surface_size, image_index, image_view,
-                                        present_time_utc_millis);
-                                  },
-                                  {}, nullptr);
+  present_queue_->EnqueueContextCallback(
+      platform_context_, {wait_queue_fence},
+      [self_token, surface_size, image_index, image_view,
+       present_time_utc_millis]() {
+        self_token.value->PerformPresent(surface_size, image_index, image_view,
+                                         present_time_utc_millis);
+      },
+      {}, nullptr);
 
   return resize_required ? PresentResult::kResizeRequired
                          : PresentResult::kSuccess;

--- a/xrtl/gfx/image.h
+++ b/xrtl/gfx/image.h
@@ -177,24 +177,6 @@ class Image : public Resource {
   virtual ref_ptr<ImageView> CreateView(Image::Type type,
                                         PixelFormat format) = 0;
 
-  // Reads a block of data from the resource at the given source layer range.
-  // This may synchronize the context queues and should be avoided. Prefer to
-  // use CopyImageToBuffer and then map the buffer instead.
-  //
-  // Returns false if the read could not be performed; either the bounds are
-  // out of range or the memory type does not support reading in this way.
-  virtual bool ReadData(LayerRange source_range, void* data,
-                        size_t data_length) = 0;
-
-  // Writes a block of data into the image at the given target layer range.
-  // This may synchronize the context queues and should be avoided. Prefer to
-  // map and populate a buffer then use CopyBufferToImage.
-  //
-  // Returns false if the write could not be performed; either the bounds are
-  // out of range or the memory type does not support writing in this way.
-  virtual bool WriteData(LayerRange target_range, const void* data,
-                         size_t data_length) = 0;
-
  protected:
   Image(size_t allocation_size, CreateParams create_params)
       : Resource(allocation_size), create_params_(create_params) {}

--- a/xrtl/gfx/resource.h
+++ b/xrtl/gfx/resource.h
@@ -24,6 +24,35 @@ namespace gfx {
 
 class MemoryHeap;
 
+// A bitmask specifying properties for a memory type.
+enum class MemoryType {
+  // Memory allocated with this type is the most efficient for device access.
+  kDeviceLocal = 1 << 0,
+
+  // Memory allocated with this type can be mapped for host access using
+  // Resource::MapMemory.
+  kHostVisible = 1 << 1,
+
+  // The host cache management commands MappedMemory::Flush and
+  // MappedMemory::Invalidate are not needed to flush host writes
+  // to the device or make device writes visible to the host, respectively.
+  kHostCoherent = 1 << 2,
+
+  // Memory allocated with this type is cached on the host. Host memory accesses
+  // to uncached memory are slower than to cached memory, however uncached
+  // memory is always host coherent.
+  kHostCached = 1 << 3,
+
+  // Memory is lazily allocated by the hardware and only exists transiently.
+  // This is the optimal mode for memory used only between subpasses in the same
+  // render pass, as it can often be kept entirely on-tile and discard when the
+  // render pass ends.
+  // The memory type only allows device access to the memory. Memory types must
+  // not have both this and kHostVisible set.
+  kLazilyAllocated = 1 << 4,
+};
+XRTL_BITMASK(MemoryType);
+
 // Base type for allocated resources.
 class Resource : public ManagedObject {
  public:

--- a/xrtl/gfx/testing/graphics_test.cc
+++ b/xrtl/gfx/testing/graphics_test.cc
@@ -188,9 +188,10 @@ bool GraphicsTest::CompareImage(
       xrtl::testing::ImageBuffer::Create(data_width, data_height, channels);
 
   // Read back the image contents into a byte buffer.
-  if (!image_view->image()->ReadData(image_view->layer_range(),
-                                     image_buffer->data(),
-                                     image_buffer->data_size())) {
+  if (!test_context()->ReadImageData(
+          image_view->image(),
+          {{image_view->layer_range(), image_buffer->data(),
+            image_buffer->data_size()}})) {
     LOG(ERROR) << "Failed to read back image contents";
     return false;
   }

--- a/xrtl/gfx/testing/graphics_test_test.cc
+++ b/xrtl/gfx/testing/graphics_test_test.cc
@@ -54,9 +54,9 @@ class GraphicsTestTest : public GraphicsTest {
 
     // Write data directly into the image.
     // A real app would want to use a staging buffer.
-    if (!grid_image->WriteData(grid_image->entire_range(),
-                               grid_image_buffer->data(),
-                               grid_image_buffer->data_size())) {
+    if (!test_context()->WriteImageData(
+            grid_image, {{grid_image->entire_range(), grid_image_buffer->data(),
+                          grid_image_buffer->data_size()}})) {
       LOG(ERROR) << "Failed to write data into texture image";
       return nullptr;
     }

--- a/xrtl/ui/imgui_overlay.cc
+++ b/xrtl/ui/imgui_overlay.cc
@@ -214,8 +214,9 @@ bool ImGuiOverlay::InitializeFont(ImGuiIO* io) {
   // Upload initial font altas data.
   // TODO(benvanik): is invalidation possible?
   // TODO(benvanik): probably worth transitioning to optimal.
-  if (!font_image->WriteData(font_image->entire_range(), pixel_data,
-                             width * height * 4)) {
+  if (!context_->WriteImageData(font_image,
+                                {{font_image->entire_range(), pixel_data,
+                                  static_cast<size_t>(width * height * 4)}})) {
     LOG(ERROR) << "Failed to write data into font image";
     return false;
   }


### PR DESCRIPTION
As it was the ReadData/WriteData methods were unsafe unless you glFinished
(or did crazy things in vk/mtl). This preserves the handy synchronous
read/write but also enables properly synchronized versions.

The Read/Writes now support scatter/gather usage, which will really
help dynamic writes generated during command buffer construction (for UBO
data, etc).

Vk/mtl implementations may be able to exploit memory types to optimize the
synchronous read/write variants (such as when the memory is Shared/host
visible), but since GL can't this has to remain a detail hidden by the
API.

The ES3 backend is not yet optimized and should really have a dedicated
transfer queue performing the reads/writes and staging buffers to do the
copies. This change is just about getting the API sane, though.